### PR TITLE
「refactor」(Validation): 精简重复校验并明确信任边界

### DIFF
--- a/src/iris/agents/config/base.py
+++ b/src/iris/agents/config/base.py
@@ -211,7 +211,7 @@ class AgentContextConfig(BaseModel):
             raise ValueError("context.path 不能为空")
         config_path: Path | None = (info.context or {}).get("config_path")
         if config_path is not None:
-            p = Path(value) if isinstance(value, str) else Path(value)
+            p = Path(value)
             if not p.is_absolute():
                 return (config_path.parent / p).resolve()
         return value
@@ -241,18 +241,6 @@ class AgentConfig(BaseModel):
     session: SessionConfig = Field(default_factory=SessionConfig)
 
     model_config = ConfigDict(extra="forbid", frozen=True)
-
-    @model_validator(mode="before")
-    @classmethod
-    def _validate_prompt_source_keys(cls, data: Any) -> Any:
-        """校验 system 和 context 配置键只能二选一。"""
-        if not isinstance(data, dict):
-            return data
-        has_system = "system" in data
-        has_context = "context" in data
-        if has_system == has_context:
-            raise ValueError("system 和 context 必须且只能配置一个")
-        return data
 
     @model_validator(mode="before")
     @classmethod

--- a/src/iris/context/builder.py
+++ b/src/iris/context/builder.py
@@ -97,7 +97,7 @@ class ContextBuilder:
                 template_context,
             )
         else:
-            rendered = self.xml_renderer.render_section(
+            rendered = self.xml_renderer._render_trusted_section(
                 _ROOT_TAGS[section_name],
                 enabled_slots,
             )

--- a/src/iris/context/models.py
+++ b/src/iris/context/models.py
@@ -23,7 +23,7 @@ class ContextSlot(BaseModel):
 
     name: str
     content: Any
-    order: int = 100
+    order: int = Field(default=100, strict=True)
     attributes: dict[str, str] = Field(default_factory=dict)
     enabled: bool = True
 
@@ -36,13 +36,6 @@ class ContextSlot(BaseModel):
             raise IrisContextError("context slot 名称不能为空")
         if not _is_safe_xml_name(value):
             raise IrisContextError("context slot 名称必须是安全的 XML 标签名")
-        return value
-
-    @field_validator("order", mode="before")
-    @classmethod
-    def _validate_order(cls, value: Any) -> Any:
-        if isinstance(value, bool):
-            raise IrisContextError("context slot 顺序不能是布尔值")
         return value
 
     @field_validator("attributes")
@@ -58,7 +51,7 @@ class ContextSection(BaseModel):
     """单个固定消息位置的模板、字符上限和 slot。"""
 
     template: Path | None = None
-    max_chars: int | None = None
+    max_chars: int | None = Field(default=None, strict=True, gt=0)
     slots: list[ContextSlot] = Field(default_factory=list)
 
     model_config = ConfigDict(extra="forbid")
@@ -68,20 +61,6 @@ class ContextSection(BaseModel):
     def _validate_template(cls, value: Path | None) -> Path | None:
         if value is not None and not value.is_absolute():
             raise IrisContextError("context 模板路径必须是绝对路径", path=str(value))
-        return value
-
-    @field_validator("max_chars", mode="before")
-    @classmethod
-    def _validate_max_chars_type(cls, value: Any) -> Any:
-        if isinstance(value, bool):
-            raise IrisContextError("context section 字符上限不能是布尔值")
-        return value
-
-    @field_validator("max_chars")
-    @classmethod
-    def _validate_max_chars(cls, value: int | None) -> int | None:
-        if value is not None and value <= 0:
-            raise IrisContextError("context section 字符上限必须为正数")
         return value
 
 

--- a/src/iris/context/renderer.py
+++ b/src/iris/context/renderer.py
@@ -21,6 +21,14 @@ class ContextXmlRenderer:
         """将一个 section 的 slot 渲染为 XML。"""
         if not _is_safe_xml_name(root_tag):
             raise IrisContextError("context XML 根标签必须是安全的 XML 名称")
+        return self._render_trusted_section(root_tag, slots)
+
+    def _render_trusted_section(
+        self,
+        root_tag: str,
+        slots: list[ContextSlot],
+    ) -> str:
+        """渲染框架已验证或固定定义的 XML 根标签。"""
         rendered_slots = [self.render_slot(slot) for slot in slots]
         body = "\n".join(_indent(slot_xml, spaces=2) for slot_xml in rendered_slots)
         return f"<{root_tag}>\n{body}\n</{root_tag}>"

--- a/src/iris/harness/_commit_port.py
+++ b/src/iris/harness/_commit_port.py
@@ -58,6 +58,7 @@ class StoreRuntimeCommitPort(RuntimeCommitPort):
         store: LifecycleStore,
         run: RunRecord,
         activation_id: str,
+        cursor: RuntimeCursor,
         clock: Callable[[], datetime],
         event_sink: list[RunEvent],
         durable_event_callback: Callable[[RunEvent], None] | None = None,
@@ -68,9 +69,12 @@ class StoreRuntimeCommitPort(RuntimeCommitPort):
         checkpoint = store.load_checkpoint(run.run_id)
         if checkpoint is None or checkpoint.activation_id != activation_id:
             raise IrisRunConflictError("commit port checkpoint activation 不匹配")
+        if checkpoint.engine_cursor != cursor.model_dump(mode="json"):
+            raise IrisRunConflictError("commit port cursor 与 durable checkpoint 不匹配")
         self._store = store
         self._run = run
         self._checkpoint = checkpoint
+        self._cursor = cursor
         self._session_revision = store.load_session(run.session_id).revision
         self._activation_id = activation_id
         self._clock = clock
@@ -87,6 +91,16 @@ class StoreRuntimeCommitPort(RuntimeCommitPort):
     def run(self) -> RunRecord:
         """返回最近一次成功 store commit 的 run record。"""
         return self._run
+
+    @property
+    def cursor(self) -> RuntimeCursor:
+        """返回最近一次成功 store commit 的 typed cursor。"""
+        return self._cursor
+
+    @property
+    def checkpoint(self) -> RunCheckpoint:
+        """返回最近一次成功 store commit 的 durable checkpoint。"""
+        return self._checkpoint
 
     def revoke(self) -> None:
         """撤销该 activation 后续所有 mutation 权限。"""
@@ -162,8 +176,7 @@ class StoreRuntimeCommitPort(RuntimeCommitPort):
                 now=now,
             )
         )
-        self._accept(stored)
-        return self._stored_cursor(commit.cursor_after)
+        return self._accept_checkpoint(stored, checkpoint, commit.cursor_after)
 
     def claim_tool_call(self, call: RuntimeToolCall) -> ToolCallClaim:
         """验证 exact prepared subject 并在 effect 前 durable claim。"""
@@ -238,8 +251,7 @@ class StoreRuntimeCommitPort(RuntimeCommitPort):
                 now=self._clock(),
             )
         )
-        self._accept(stored)
-        return self._stored_cursor(commit.cursor_after)
+        return self._accept_checkpoint(stored, checkpoint, commit.cursor_after)
 
     def suspend(self, suspension: RuntimeSuspension) -> RuntimeSuspensionResult:
         """原子提交模型事实、pending interaction 与 waiting result。"""
@@ -283,12 +295,12 @@ class StoreRuntimeCommitPort(RuntimeCommitPort):
                 now=now,
             )
         )
-        self._accept(stored)
+        committed_cursor = self._accept_checkpoint(stored, checkpoint, suspension.cursor)
         self._writable = False
         if stored.interaction is None:
             raise IrisRunStateError("suspend commit 缺少 durable interaction")
         return RuntimeSuspensionResult(
-            cursor=self._stored_cursor(suspension.cursor),
+            cursor=committed_cursor,
             interaction=stored.interaction,
         )
 
@@ -311,6 +323,19 @@ class StoreRuntimeCommitPort(RuntimeCommitPort):
         if commit.session is not None:
             self._session_revision = commit.session.revision
         self._record_events(commit.events)
+
+    def _accept_checkpoint(
+        self,
+        commit: RunCommit,
+        expected_checkpoint: RunCheckpoint,
+        cursor: RuntimeCursor,
+    ) -> RuntimeCursor:
+        """接受精确 checkpoint commit 并推进同进程 typed cursor。"""
+        self._accept(commit)
+        if self._checkpoint != expected_checkpoint:
+            raise IrisRunConflictError("store 返回了意外 checkpoint")
+        self._cursor = cursor
+        return cursor
 
     def _require_writable(self) -> None:
         if not self._writable:
@@ -404,7 +429,7 @@ class StoreRuntimeCommitPort(RuntimeCommitPort):
                 )
 
     def _require_cursor(self, cursor: RuntimeCursor) -> None:
-        if RuntimeCursor.model_validate(self._checkpoint.engine_cursor) != cursor:
+        if self._cursor != cursor:
             raise IrisRunConflictError("runtime cursor 与 durable checkpoint 不匹配")
 
     def _require_runtime_call(self, call: RuntimeToolCall) -> None:
@@ -545,12 +570,6 @@ class StoreRuntimeCommitPort(RuntimeCommitPort):
             step_index=suspension.cursor.step_index,
             expires_at=expires_at,
         )
-
-    def _stored_cursor(self, expected: RuntimeCursor) -> RuntimeCursor:
-        actual = RuntimeCursor.model_validate(self._checkpoint.engine_cursor)
-        if actual != expected:
-            raise IrisRunConflictError("store 返回的 checkpoint cursor 与 commit 不匹配")
-        return actual
 
 
 __all__ = ["StoreRuntimeCommitPort"]

--- a/src/iris/harness/runner.py
+++ b/src/iris/harness/runner.py
@@ -225,11 +225,7 @@ class AgentRunner:
 
         ``observer_event_timeout_s`` 必须是有限正数；默认 30 秒。
         """
-        if (
-            isinstance(observer_event_timeout_s, bool)
-            or not math.isfinite(observer_event_timeout_s)
-            or observer_event_timeout_s <= 0
-        ):
+        if not math.isfinite(observer_event_timeout_s) or observer_event_timeout_s <= 0:
             raise ValueError("observer_event_timeout_s 必须是有限正数")
         self.runtime = runtime
         self.store = store
@@ -241,10 +237,7 @@ class AgentRunner:
         self.interaction_service = interaction_service or HumanInteractionService()
         # HITL 决定必须只落在 runner 的 aggregate transaction 里；带自有 store 的实现会
         # 造成第二条持久化路径，因此在装配期直接拒绝。
-        if hasattr(self.interaction_service, "store") or any(
-            not callable(getattr(self.interaction_service, name, None))
-            for name in ("create_pending", "validate_response", "project_response")
-        ):
+        if hasattr(self.interaction_service, "store"):
             raise IrisRunStateError("runner interaction service 必须是无状态领域服务")
         self.environment_fingerprint = compute_environment_fingerprint(runtime)
         self._active: dict[str, ActiveActivation] = {}
@@ -403,6 +396,7 @@ class AgentRunner:
             store=self.store,
             run=created.run,
             activation_id=activation_id,
+            cursor=cursor,
             clock=self._now,
             event_sink=active.events,
             durable_event_callback=durable_event_callback,
@@ -561,7 +555,12 @@ class AgentRunner:
             raise IrisRunConflictError("rebound checkpoint cursor 与 waiting checkpoint 不匹配")
         # HITL 领域模型与 runtime 输入模型是两套边界类型，批准分支需要显式转换。
         runtime_projection = (
-            RuntimeApprovedToolCall.model_validate(projection.model_dump())
+            RuntimeApprovedToolCall.model_construct(
+                interaction_id=projection.interaction_id,
+                tool_call_id=projection.tool_call_id,
+                tool_name=projection.tool_name,
+                fingerprint=projection.fingerprint,
+            )
             if isinstance(projection, ApprovedToolCall)
             else projection
         )
@@ -577,6 +576,7 @@ class AgentRunner:
             store=self.store,
             run=begun.run,
             activation_id=activation_id,
+            cursor=cursor,
             clock=self._now,
             event_sink=active.events,
             durable_event_callback=durable_event_callback,
@@ -811,7 +811,7 @@ class AgentRunner:
             return self._require_result(run.run_id)
         if recovered.checkpoint is None or recovered_cursor is None or new_activation_id is None:
             raise IrisRunRecoveryError("recover commit 缺少 rebound activation facts")
-        if RuntimeCursor.model_validate(recovered.checkpoint.engine_cursor) != recovered_cursor:
+        if recovered.checkpoint.engine_cursor != recovered_cursor.model_dump(mode="json"):
             raise IrisRunConflictError("recover rebound checkpoint cursor 已变化")
 
         # --- 5. 绑定新 activation 并继续推进 ---
@@ -826,6 +826,7 @@ class AgentRunner:
             store=self.store,
             run=recovered.run,
             activation_id=new_activation_id,
+            cursor=recovered_cursor,
             clock=self._now,
             event_sink=active.events,
             interaction_service=self.interaction_service,
@@ -1046,21 +1047,17 @@ class AgentRunner:
             expiry = (
                 interaction.expires_at if interaction.status is InteractionStatus.PENDING else None
             )
-            deadline_due = deadline is not None and now >= deadline
-            expiry_due = expiry is not None and now >= expiry
-            if deadline_due and expiry_due:
-                if deadline is None or expiry is None:  # pragma: no cover - 已由 due facts 收窄
-                    raise IrisRunStateError("waiting due facts 不完整")
+            if deadline is not None and expiry is not None and now >= deadline and now >= expiry:
                 stop_reason = (
                     RunStopReason.DEADLINE_EXCEEDED
                     if deadline <= expiry
                     else RunStopReason.INTERACTION_EXPIRED
                 )
                 close_reason = stop_reason.value
-            elif deadline_due:
+            elif deadline is not None and now >= deadline:
                 stop_reason = RunStopReason.DEADLINE_EXCEEDED
                 close_reason = "deadline_exceeded"
-            elif expiry_due:
+            elif expiry is not None and now >= expiry:
                 stop_reason = RunStopReason.INTERACTION_EXPIRED
                 close_reason = "interaction_expired"
         if stop_reason is None:
@@ -1200,7 +1197,6 @@ class AgentRunner:
         port: StoreRuntimeCommitPort,
     ) -> None:
         """把被中断的 async operation 映射为可证明的 durable outcome。"""
-        del port  # settlement 走 runner 自己的 finish_run，不复用已收口的 activation port。
         current = self.store.load_run(active.run_id)
         if current is None:
             raise IrisRunNotFoundError("run 在 cancellation 期间消失", run_id=active.run_id)
@@ -1247,16 +1243,12 @@ class AgentRunner:
         port: StoreRuntimeCommitPort,
     ) -> None:
         """校验 engine outcome 与 durable 事实一致后结算 run。"""
-        del port  # settlement 走 runner 自己的 finish_run，不复用已收口的 activation port。
         current = self.store.load_run(active.run_id)
         if current is None:
             raise IrisRunNotFoundError("run 在 activation 期间消失", run_id=active.run_id)
         # engine 的最终 cursor 必须已经落库，否则说明有 commit 丢失或被其它 activation 覆盖。
         checkpoint = self.store.load_checkpoint(active.run_id)
-        if (
-            checkpoint is None
-            or RuntimeCursor.model_validate(checkpoint.engine_cursor) != result.cursor
-        ):
+        if port.cursor != result.cursor or checkpoint != port.checkpoint:
             raise IrisRunConflictError("engine outcome cursor 与 durable checkpoint 不匹配")
         if current.phase is RunPhase.TERMINAL:
             return

--- a/src/iris/harness/session_manager.py
+++ b/src/iris/harness/session_manager.py
@@ -69,7 +69,7 @@ type SubmissionFailureReason = Literal[
 
 
 def _require_positive_capacity(value: int, *, name: str) -> None:
-    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+    if value <= 0:
         raise ValueError(f"{name} 必须是正整数")
 
 
@@ -166,7 +166,8 @@ class _EventPageReader(Protocol):
     ) -> list[RunEvent]: ...
 
 
-class _PendingInput(BaseModel):
+@dataclass(frozen=True, slots=True)
+class _PendingInput:
     """尚未证明 durable delivery 的单条 transient input。
 
     Attributes:
@@ -177,28 +178,11 @@ class _PendingInput(BaseModel):
         options (AgentRunOptions | None): 仅 follow-up 可携带，用于其未来的 run create。
     """
 
-    model_config = ConfigDict(frozen=True, extra="forbid", arbitrary_types_allowed=True)
-
     submission_id: str
     input: str
     mode: SubmissionMode
     run_id: str
     options: AgentRunOptions | None = None
-
-    @field_validator("submission_id", "input", "run_id")
-    @classmethod
-    def _validate_required_text(cls, value: str, info: ValidationInfo) -> str:
-        normalized = value.strip()
-        if not normalized:
-            raise ValueError(f"{info.field_name} 不能为空")
-        return normalized
-
-    @model_validator(mode="after")
-    def _validate_options(self) -> _PendingInput:
-        # steer 加入的是已存在 run，其 options 早已 durable，不能再被覆盖。
-        if self.mode == "steer" and self.options is not None:
-            raise ValueError("steer input 不接受 run options")
-        return self
 
 
 class _PendingInputQueue:
@@ -593,7 +577,7 @@ class _SessionSteeringPort:
                 return None
             # 已离开队列但尚未证明 durable delivery，暂存等待 acknowledge/fail 回调结算。
             manager._claimed_steer[item.submission_id] = item
-            return SteeringInput(
+            return SteeringInput.model_construct(
                 submission_id=item.submission_id,
                 message=Msg.user(
                     item.input,

--- a/src/iris/hitl/models.py
+++ b/src/iris/hitl/models.py
@@ -96,7 +96,7 @@ class ToolCallSnapshot(BaseModel):
 
     model_config = ConfigDict(extra="forbid", use_enum_values=False)
 
-    @field_validator("tool_call_id", "tool_name", "workspace_root", "fingerprint")
+    @field_validator("tool_call_id", "tool_name", "workspace_root")
     @classmethod
     def _validate_required_text(cls, value: str, info: ValidationInfo) -> str:
         return _trim_required(value, field_name=str(info.field_name))
@@ -187,7 +187,7 @@ class ApprovedToolCall(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    @field_validator("interaction_id", "tool_call_id", "tool_name", "fingerprint")
+    @field_validator("interaction_id", "tool_call_id", "tool_name")
     @classmethod
     def _validate_required_text(cls, value: str, info: ValidationInfo) -> str:
         return _trim_required(value, field_name=str(info.field_name))

--- a/src/iris/hitl/service.py
+++ b/src/iris/hitl/service.py
@@ -19,7 +19,6 @@ from .models import (
     HumanInteractionRequest,
     HumanInteractionResponse,
     InteractionStatus,
-    PermissionInteractionResponse,
     QuestionInteractionResponse,
 )
 
@@ -40,7 +39,7 @@ class HumanInteractionService:
             raise IrisRunStateError("只有 active run 可以创建 interaction", run_id=run.run_id)
         if run.pending_interaction_id is not None:
             raise IrisRunStateError("active run 已包含 pending interaction", run_id=run.run_id)
-        normalized_expiry = _aware_utc(expires_at, field_name="expires_at")
+        normalized_expiry = _optional_aware_utc(expires_at, field_name="expires_at")
         if normalized_expiry is not None and normalized_expiry <= run.updated_at:
             raise IrisRunStateError("interaction expiry 必须晚于创建时间", run_id=run.run_id)
         return HumanInteraction(
@@ -64,8 +63,6 @@ class HumanInteractionService:
     ) -> None:
         """校验一次 response 是否能安全绑定当前 durable waiting facts。"""
         normalized_now = _aware_utc(now, field_name="now")
-        if normalized_now is None:  # pragma: no cover - ``now`` 的签名不允许 None
-            raise IrisRunStateError("now 不能为空")
         if run.phase is not RunPhase.WAITING:
             raise IrisRunStateError("只有 waiting run 可以接收 interaction response")
         if (
@@ -107,8 +104,6 @@ class HumanInteractionService:
                 content=[TextBlock(text=response.answer)],
                 data={"answer": response.answer},
             )
-        if not isinstance(response, PermissionInteractionResponse):
-            raise HITLResponseMismatchError("未知 interaction response 类型")
         if response.decision == "reject":
             return ToolResult(
                 tool_use_id=subject.tool_call_id,
@@ -127,12 +122,20 @@ class HumanInteractionService:
         )
 
 
-def _aware_utc(value: datetime | None, *, field_name: str) -> datetime | None:
-    if value is None:
-        return None
+def _aware_utc(value: datetime, *, field_name: str) -> datetime:
     if value.tzinfo is None or value.utcoffset() is None:
         raise IrisRunStateError(f"{field_name} 必须包含时区")
     return value.astimezone(UTC)
+
+
+def _optional_aware_utc(
+    value: datetime | None,
+    *,
+    field_name: str,
+) -> datetime | None:
+    if value is None:
+        return None
+    return _aware_utc(value, field_name=field_name)
 
 
 __all__ = ["HumanInteractionService"]

--- a/src/iris/lifecycle/README.en.md
+++ b/src/iris/lifecycle/README.en.md
@@ -3,8 +3,10 @@
 # `iris.lifecycle`
 
 `iris.lifecycle` is the pure data and synchronous store contract for logical runs. It defines
-immutable run/session/activation/checkpoint/tool-call/event/result models, JSON-safe validation,
-projections, and CAS commands. It owns neither execution control flow nor a concrete database.
+immutable run/session/activation/checkpoint/tool-call/event/result boundary models, JSON-safe
+validation, projections, and CAS commands. Persisted models use Pydantic to validate raw/load data;
+same-process commands are frozen slots dataclasses carrying already typed facts. The package owns
+neither execution control flow nor a concrete database.
 
 ## Dependency boundary
 
@@ -42,6 +44,10 @@ provider clients, tasks, locks, signals, or callbacks.
 cancellation/finish/recover commands plus run/session/lane/interaction/checkpoint/tool/result/event
 reads.
 Every mutation carries expected revision/fence facts; stale writers conflict instead of overwriting.
+Stores validate only the phase, counters, identity, and fence affected by the mutation, then apply a
+typed delta. They do not dump and fully revalidate an unchanged aggregate for a one-field update.
+SQLite rows and checkpoint recovery remain full-validation boundaries, while durable models and
+encoders retain JSON-safe guarantees.
 `SessionSnapshot` still exposes only `session_id`, CAS `revision`, and complete `messages`. Revision
 advances once per non-empty message delta regardless of how many messages that delta contains.
 Persistence message counts and ordinals do not enter lifecycle public models or commands.

--- a/src/iris/lifecycle/README.md
+++ b/src/iris/lifecycle/README.md
@@ -3,8 +3,9 @@
 # `iris.lifecycle`
 
 `iris.lifecycle` 是 logical run 的纯数据与同步 store contract。它定义不可变 run/session/
-activation/checkpoint/tool-call/event/result 模型、JSON-safe validation、投影函数和 CAS commands，
-但不拥有运行控制流或具体数据库。
+activation/checkpoint/tool-call/event/result 边界模型、JSON-safe validation、投影函数和 CAS
+commands，但不拥有运行控制流或具体数据库。持久化模型使用 Pydantic 校验 raw/load 数据；
+同进程 command 使用 frozen slots dataclass，只携带调用方已经类型化的事实。
 
 ## 依赖边界
 
@@ -44,6 +45,9 @@ checkpoint 只接受当前 payload 形状，也不保存 provider client、task�
 cancellation/finish/recover commands，以及 run/session/lane/interaction/checkpoint/tool/result/event
 reads。
 每个 mutation command 携带 expected revision/fence；stale writer 必须 conflict，而不是覆盖新事实。
+Store 只校验当前 mutation 影响的 phase、counter、identity 与 fence，再应用 typed delta；不会为了
+更新单个字段而把整个已验证 aggregate `model_dump()` 后重新 `model_validate()`。SQLite row 与
+checkpoint recovery 仍是完整验证边界，JSON-safe 约束仍由 durable model/encoder 保证。
 `SessionSnapshot` 继续只公开 `session_id`、CAS `revision` 和完整 `messages`。revision 每次非空
 message delta 只推进一次，与 delta 中的消息条数无关；持久化层的 message count 与 ordinal
 不进入 lifecycle 公共模型或 command。

--- a/src/iris/lifecycle/models.py
+++ b/src/iris/lifecycle/models.py
@@ -608,7 +608,7 @@ class RunToolCallRecord(_FrozenModel):
     claimed_at: datetime | None = None
     committed_at: datetime | None = None
 
-    @field_validator("run_id", "tool_call_id", "tool_name", "fingerprint")
+    @field_validator("run_id", "tool_call_id", "tool_name")
     @classmethod
     def _validate_required_text(cls, value: str, info: ValidationInfo) -> str:
         return _trim_required(value, field_name=str(info.field_name))
@@ -694,7 +694,7 @@ class RunEvent(_FrozenModel):
 
 def snapshot_run(record: RunRecord) -> RunSnapshot:
     """从权威 record 生成不可变 public snapshot。"""
-    return RunSnapshot(
+    return RunSnapshot.model_construct(
         run_id=record.run_id,
         session_id=record.session_id,
         agent_id=record.agent_id,
@@ -728,15 +728,12 @@ def project_result(
     """
     if record.phase is RunPhase.ACTIVE:
         raise IrisRunStateError("active run 不产生 RunResult", run_id=record.run_id)
-    try:
-        return RunResult(
-            run=snapshot_run(record),
-            assistant_message=record.assistant_message,
-            pending_interaction=interaction,
-            error=record.error,
-        )
-    except ValueError as exc:
-        raise IrisRunStateError("run result facts 不一致", run_id=record.run_id) from exc
+    return RunResult.model_construct(
+        run=snapshot_run(record),
+        assistant_message=record.assistant_message,
+        pending_interaction=interaction,
+        error=record.error,
+    )
 
 
 __all__ = [

--- a/src/iris/lifecycle/store.py
+++ b/src/iris/lifecycle/store.py
@@ -9,10 +9,9 @@ Example:
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Protocol
-
-from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
 
 from ..hitl.models import HumanInteraction, HumanInteractionResponse
 from ..message.message import Msg
@@ -32,18 +31,11 @@ from .models import (
     RunToolCallRecord,
     RunUsage,
     SessionSnapshot,
-    _required_aware_utc,
-    _trim_required,
 )
 
 
-class _Command(BaseModel):
-    """Mutation command 的统一不可变配置。"""
-
-    model_config = ConfigDict(extra="forbid", frozen=True, use_enum_values=False)
-
-
-class CreateRun(_Command):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CreateRun:
     """原子创建 logical run、session lane 与初始 activation。"""
 
     request: AgentRunRequest
@@ -54,18 +46,8 @@ class CreateRun(_Command):
     initial_checkpoint: RunCheckpoint
     now: datetime
 
-    @field_validator("agent_id", "environment_fingerprint", "start_activation_id")
-    @classmethod
-    def _validate_required_text(cls, value: str, info: ValidationInfo) -> str:
-        return _trim_required(value, field_name=str(info.field_name))
-
-    @field_validator("now")
-    @classmethod
-    def _validate_now(cls, value: datetime) -> datetime:
-        return _required_aware_utc(value, field_name="now")
-
-    @model_validator(mode="after")
-    def _validate_initial_facts(self) -> CreateRun:
+    def __post_init__(self) -> None:
+        """校验初始 checkpoint 与 run identity 的跨字段约束。"""
         if self.request.run_id is None:
             raise ValueError("CreateRun request 必须包含最终 run_id")
         if self.initial_checkpoint.run_id != self.request.run_id:
@@ -76,200 +58,123 @@ class CreateRun(_Command):
             raise ValueError("initial checkpoint sequence 必须为 1")
         if self.initial_checkpoint.environment_fingerprint != self.environment_fingerprint:
             raise ValueError("initial checkpoint environment fingerprint 不匹配")
-        return self
 
 
-class ResumeWaitingRun(_Command):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ResumeWaitingRun:
     """为 resolved waiting run 创建新的 activation fence。"""
 
     run_id: str
-    expected_run_revision: int = Field(ge=0)
+    expected_run_revision: int
     new_activation_id: str
     kind: ActivationKind
-    expected_checkpoint_sequence: int = Field(ge=0)
+    expected_checkpoint_sequence: int
     now: datetime
 
-    @field_validator("run_id", "new_activation_id")
-    @classmethod
-    def _validate_required_text(cls, value: str, info: ValidationInfo) -> str:
-        return _trim_required(value, field_name=str(info.field_name))
 
-    @field_validator("now")
-    @classmethod
-    def _validate_now(cls, value: datetime) -> datetime:
-        return _required_aware_utc(value, field_name="now")
-
-
-class ReserveModelStep(_Command):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ReserveModelStep:
     """在 provider effect 前 durable 预留一个模型步。"""
 
     run_id: str
-    expected_run_revision: int = Field(ge=0)
+    expected_run_revision: int
     activation_id: str
     now: datetime
 
-    @field_validator("run_id", "activation_id")
-    @classmethod
-    def _validate_required_text(cls, value: str, info: ValidationInfo) -> str:
-        return _trim_required(value, field_name=str(info.field_name))
 
-    @field_validator("now")
-    @classmethod
-    def _validate_now(cls, value: datetime) -> datetime:
-        return _required_aware_utc(value, field_name="now")
-
-
-class CommitModelStep(_Command):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CommitModelStep:
     """原子提交模型响应、history、tool intents 与 checkpoint。"""
 
     run_id: str
-    expected_run_revision: int = Field(ge=0)
+    expected_run_revision: int
     activation_id: str
-    expected_session_revision: int = Field(ge=0)
-    message_delta: list[Msg] = Field(default_factory=list)
+    expected_session_revision: int
+    message_delta: list[Msg] = field(default_factory=list)
     usage: RunUsage
-    prepared_tool_calls: list[RunToolCallRecord] = Field(default_factory=list)
+    prepared_tool_calls: list[RunToolCallRecord] = field(default_factory=list)
     checkpoint: RunCheckpoint
     assistant_message: Msg | None = None
     now: datetime
 
-    @field_validator("run_id", "activation_id")
-    @classmethod
-    def _validate_required_text(cls, value: str, info: ValidationInfo) -> str:
-        return _trim_required(value, field_name=str(info.field_name))
 
-    @field_validator("now")
-    @classmethod
-    def _validate_now(cls, value: datetime) -> datetime:
-        return _required_aware_utc(value, field_name="now")
-
-
-class ClaimToolCall(_Command):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ClaimToolCall:
     """在工具副作用前 durable claim 一次 prepared 调用。"""
 
     run_id: str
-    expected_run_revision: int = Field(ge=0)
+    expected_run_revision: int
     activation_id: str
     tool_call_id: str
     fingerprint: str
-    expected_tool_version: int = Field(ge=0)
+    expected_tool_version: int
     now: datetime
 
-    @field_validator("run_id", "activation_id", "tool_call_id", "fingerprint")
-    @classmethod
-    def _validate_required_text(cls, value: str, info: ValidationInfo) -> str:
-        return _trim_required(value, field_name=str(info.field_name))
 
-    @field_validator("now")
-    @classmethod
-    def _validate_now(cls, value: datetime) -> datetime:
-        return _required_aware_utc(value, field_name="now")
-
-
-class CommitToolResult(_Command):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CommitToolResult:
     """原子提交一次精确工具结果、history 与 checkpoint。"""
 
     run_id: str
-    expected_run_revision: int = Field(ge=0)
+    expected_run_revision: int
     activation_id: str
-    expected_session_revision: int = Field(ge=0)
+    expected_session_revision: int
     tool_call_id: str
-    expected_tool_version: int = Field(ge=0)
+    expected_tool_version: int
     result: ToolResult
-    message_delta: list[Msg] = Field(default_factory=list)
+    message_delta: list[Msg] = field(default_factory=list)
     checkpoint: RunCheckpoint
     now: datetime
 
-    @field_validator("run_id", "activation_id", "tool_call_id")
-    @classmethod
-    def _validate_required_text(cls, value: str, info: ValidationInfo) -> str:
-        return _trim_required(value, field_name=str(info.field_name))
 
-    @field_validator("now")
-    @classmethod
-    def _validate_now(cls, value: datetime) -> datetime:
-        return _required_aware_utc(value, field_name="now")
-
-
-class SuspendRun(_Command):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class SuspendRun:
     """原子提交当前模型步并将 active run 转为 waiting。"""
 
     run_id: str
-    expected_run_revision: int = Field(ge=0)
+    expected_run_revision: int
     activation_id: str
-    expected_session_revision: int = Field(ge=0)
-    message_delta: list[Msg] = Field(default_factory=list)
-    prepared_tool_calls: list[RunToolCallRecord] = Field(default_factory=list)
+    expected_session_revision: int
+    message_delta: list[Msg] = field(default_factory=list)
+    prepared_tool_calls: list[RunToolCallRecord] = field(default_factory=list)
     checkpoint: RunCheckpoint
     pending_interaction: HumanInteraction
     assistant_message: Msg | None = None
     usage: RunUsage
     now: datetime
 
-    @field_validator("run_id", "activation_id")
-    @classmethod
-    def _validate_required_text(cls, value: str, info: ValidationInfo) -> str:
-        return _trim_required(value, field_name=str(info.field_name))
 
-    @field_validator("now")
-    @classmethod
-    def _validate_now(cls, value: datetime) -> datetime:
-        return _required_aware_utc(value, field_name="now")
-
-
-class ResolveInteraction(_Command):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ResolveInteraction:
     """以 response/version/fingerprint CAS 解决 pending interaction。"""
 
     run_id: str
-    expected_run_revision: int = Field(ge=0)
+    expected_run_revision: int
     interaction_id: str
-    expected_interaction_version: int = Field(ge=0)
+    expected_interaction_version: int
     response: HumanInteractionResponse
     expected_fingerprint: str
     now: datetime
 
-    @field_validator("run_id", "interaction_id", "expected_fingerprint")
-    @classmethod
-    def _validate_required_text(cls, value: str, info: ValidationInfo) -> str:
-        return _trim_required(value, field_name=str(info.field_name))
 
-    @field_validator("now")
-    @classmethod
-    def _validate_now(cls, value: datetime) -> datetime:
-        return _required_aware_utc(value, field_name="now")
-
-
-class RequestCancellation(_Command):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class RequestCancellation:
     """记录首次 cancellation request，可显式结算 waiting run。"""
 
     run_id: str
-    expected_run_revision: int = Field(ge=0)
+    expected_run_revision: int
     activation_id: str | None = None
     reason: str
     settle_waiting: bool = False
     now: datetime
 
-    @field_validator("run_id", "reason")
-    @classmethod
-    def _validate_required_text(cls, value: str, info: ValidationInfo) -> str:
-        return _trim_required(value, field_name=str(info.field_name))
 
-    @field_validator("activation_id")
-    @classmethod
-    def _validate_optional_activation(cls, value: str | None) -> str | None:
-        return None if value is None else _trim_required(value, field_name="activation_id")
-
-    @field_validator("now")
-    @classmethod
-    def _validate_now(cls, value: datetime) -> datetime:
-        return _required_aware_utc(value, field_name="now")
-
-
-class FinishRun(_Command):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class FinishRun:
     """将 active 或 waiting run 原子结算为 terminal。"""
 
     run_id: str
-    expected_run_revision: int = Field(ge=0)
+    expected_run_revision: int
     activation_id: str | None = None
     stop_reason: RunStopReason
     assistant_message: Msg | None = None
@@ -277,58 +182,29 @@ class FinishRun(_Command):
     interaction_close_reason: str | None = None
     now: datetime
 
-    @field_validator("run_id")
-    @classmethod
-    def _validate_run_id(cls, value: str) -> str:
-        return _trim_required(value, field_name="run_id")
 
-    @field_validator("activation_id", "interaction_close_reason")
-    @classmethod
-    def _validate_optional_text(cls, value: str | None, info: ValidationInfo) -> str | None:
-        return None if value is None else _trim_required(value, field_name=str(info.field_name))
-
-    @field_validator("now")
-    @classmethod
-    def _validate_now(cls, value: datetime) -> datetime:
-        return _required_aware_utc(value, field_name="now")
-
-
-class RecoverActiveRun(_Command):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class RecoverActiveRun:
     """根据 durable effect facts 放弃并恢复或终止旧 activation。"""
 
     run_id: str
-    expected_run_revision: int = Field(ge=0)
+    expected_run_revision: int
     expected_activation_id: str
-    expected_checkpoint_sequence: int = Field(ge=0)
+    expected_checkpoint_sequence: int
     recovery_disposition: RecoveryDisposition
     new_activation_id: str | None = None
     now: datetime
 
-    @field_validator("run_id", "expected_activation_id")
-    @classmethod
-    def _validate_required_text(cls, value: str, info: ValidationInfo) -> str:
-        return _trim_required(value, field_name=str(info.field_name))
-
-    @field_validator("new_activation_id")
-    @classmethod
-    def _validate_optional_activation(cls, value: str | None) -> str | None:
-        return None if value is None else _trim_required(value, field_name="new_activation_id")
-
-    @field_validator("now")
-    @classmethod
-    def _validate_now(cls, value: datetime) -> datetime:
-        return _required_aware_utc(value, field_name="now")
-
-    @model_validator(mode="after")
-    def _validate_disposition(self) -> RecoverActiveRun:
+    def __post_init__(self) -> None:
+        """校验 recovery disposition 与新 activation 的组合。"""
         if (self.recovery_disposition is RecoveryDisposition.RESUME) != (
             self.new_activation_id is not None
         ):
             raise ValueError("resume recovery 必须且只能包含 new_activation_id")
-        return self
 
 
-class RunCommit(_Command):
+@dataclass(frozen=True, slots=True, kw_only=True)
+class RunCommit:
     """一次 mutation 原子提交后返回的完整事实集合。"""
 
     run: RunRecord

--- a/src/iris/lifecycle/transitions.py
+++ b/src/iris/lifecycle/transitions.py
@@ -1,0 +1,145 @@
+"""Lifecycle 已验证对象的进程内状态转换。
+
+Example:
+    updated = reserve_model_step(usage)
+"""
+
+# region imports
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from ..tools.base import ToolResult
+from .models import (
+    ActivationOutcome,
+    ActivationRecord,
+    ActivationStatus,
+    RunCheckpoint,
+    RunRecord,
+    RunToolCallRecord,
+    RunUsage,
+    ToolCallPhase,
+)
+
+# endregion
+
+
+def replace_run(run: RunRecord, **changes: Any) -> RunRecord:
+    """应用已由 store 验证的 run 状态增量。"""
+    return run.model_copy(update=changes)
+
+
+def reserve_model_step(usage: RunUsage) -> RunUsage:
+    """把 model-step reservation 计数推进一次。"""
+    return usage.model_copy(update={"model_steps_reserved": usage.model_steps_reserved + 1})
+
+
+def commit_tool_usage(usage: RunUsage) -> RunUsage:
+    """把已提交工具调用计数推进一次。"""
+    return usage.model_copy(update={"tool_calls_committed": usage.tool_calls_committed + 1})
+
+
+def rebind_checkpoint(
+    checkpoint: RunCheckpoint,
+    *,
+    activation_id: str,
+) -> RunCheckpoint:
+    """把已验证 checkpoint 绑定到新的 activation fence。"""
+    return checkpoint.model_copy(update={"activation_id": activation_id})
+
+
+def settle_activation(
+    activation: ActivationRecord,
+    *,
+    outcome: ActivationOutcome,
+    ended_at: datetime,
+) -> ActivationRecord:
+    """结算当前 active activation。"""
+    return activation.model_copy(
+        update={
+            "status": ActivationStatus.SETTLED,
+            "outcome": outcome,
+            "ended_at": ended_at,
+        }
+    )
+
+
+def abandon_activation(
+    activation: ActivationRecord,
+    *,
+    outcome: ActivationOutcome,
+    ended_at: datetime,
+) -> ActivationRecord:
+    """把旧 activation 标记为恢复流程已放弃。"""
+    return activation.model_copy(
+        update={
+            "status": ActivationStatus.ABANDONED,
+            "outcome": outcome,
+            "ended_at": ended_at,
+        }
+    )
+
+
+def claim_tool_call(
+    tool_call: RunToolCallRecord,
+    *,
+    activation_id: str,
+    now: datetime,
+) -> RunToolCallRecord:
+    """应用 prepared 到 claimed 的已验证增量。"""
+    return tool_call.model_copy(
+        update={
+            "phase": ToolCallPhase.CLAIMED,
+            "claim_activation_id": activation_id,
+            "version": tool_call.version + 1,
+            "updated_at": now,
+            "claimed_at": now,
+        }
+    )
+
+
+def commit_tool_call(
+    tool_call: RunToolCallRecord,
+    *,
+    result: ToolResult,
+    now: datetime,
+) -> RunToolCallRecord:
+    """应用 prepared/claimed 到 committed 的已验证增量。"""
+    return tool_call.model_copy(
+        update={
+            "phase": ToolCallPhase.COMMITTED,
+            "result": result,
+            "version": tool_call.version + 1,
+            "updated_at": now,
+            "committed_at": now,
+        }
+    )
+
+
+def mark_tool_call_outcome_unknown(
+    tool_call: RunToolCallRecord,
+    *,
+    now: datetime,
+) -> RunToolCallRecord:
+    """把已 claim 且结果未知的工具调用标记为 outcome unknown。"""
+    return tool_call.model_copy(
+        update={
+            "phase": ToolCallPhase.OUTCOME_UNKNOWN,
+            "version": tool_call.version + 1,
+            "updated_at": now,
+        }
+    )
+
+
+__all__ = [
+    "abandon_activation",
+    "claim_tool_call",
+    "commit_tool_call",
+    "commit_tool_usage",
+    "mark_tool_call_outcome_unknown",
+    "rebind_checkpoint",
+    "replace_run",
+    "reserve_model_step",
+    "settle_activation",
+]

--- a/src/iris/memory/README.en.md
+++ b/src/iris/memory/README.en.md
@@ -131,8 +131,10 @@ tool-payload helpers are not extension contracts.
 `register_memory_tools()` exposes only `memory_search`, `memory_list`, and `memory_get`, all with
 `READ` capability. There are no model-visible remember/forget tools. Tool input cannot override the
 scope; `MemoryAccessPolicy` derives read/write scopes from trusted host context and can include the
-workspace-shared scope. Tools evaluate that policy on the event loop, then submit the entire
-multi-scope read as one service job rather than switching threads once per scope.
+workspace-shared scope. `MemoryQuery`, `memory_search`, and `memory_list` all declare a `1..100`
+limit. After raw tool input passes that boundary, it is projected to a trusted `MemoryQuery`
+without repeating the same range validation. Tools evaluate access policy on the event loop, then
+submit the entire multi-scope read as one service job rather than switching threads once per scope.
 
 `FileMemoryMirror` creates the fixed Memory/User/Feedback/Reference/Tasks/Sessions projection and
 can deterministically rebuild active items plus the most recent 100 events for one scope. It is not

--- a/src/iris/memory/README.md
+++ b/src/iris/memory/README.md
@@ -150,6 +150,8 @@ result = await runner.start(
 
 工具输入不能覆盖 scope。`MemoryAccessPolicy` 由宿主上下文计算写 scope 与可读 scope；默认
 可同时读取自身 scope 和约定的 workspace-shared scope，并按 item ID 去重。
+`MemoryQuery`、`memory_search` 与 `memory_list` 的 `limit` 都声明为 `1..100`；工具输入在 raw
+边界验证后投影为 trusted `MemoryQuery`，不会重复校验相同范围。
 工具会先在事件循环执行 access policy，再把完整的多 scope 读取作为一个 service job 调度；
 不会按 scope 重复切换线程。
 

--- a/src/iris/memory/models.py
+++ b/src/iris/memory/models.py
@@ -230,8 +230,8 @@ class MemoryItem(BaseModel):
     source_type: MemorySourceType = MemorySourceType.SDK
     source_id: str = ""
     reason: str = ""
-    confidence: float | None = None
-    importance: float | None = None
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    importance: float | None = Field(default=None, ge=0.0, le=1.0)
     artifacts: list[MemoryArtifactRef] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
     created_at: str = Field(default_factory=_now_iso)
@@ -248,14 +248,6 @@ class MemoryItem(BaseModel):
             raise ValueError("记忆正文不能为空")
         return value
 
-    @field_validator("confidence", "importance")
-    @classmethod
-    def _validate_score(cls, value: float | None) -> float | None:
-        """校验置信度与重要性分数范围。"""
-        if value is not None and not 0.0 <= value <= 1.0:
-            raise ValueError("记忆分数必须在 0.0 到 1.0 之间")
-        return value
-
 
 class MemoryCandidate(BaseModel):
     """从 L1 episode 抽取出的待处理候选记忆。"""
@@ -266,8 +258,8 @@ class MemoryCandidate(BaseModel):
     category: MemoryCategory = MemoryCategory.USER
     suggested_level: MemoryLevel = MemoryLevel.SEMANTIC
     text: str
-    confidence: float | None = None
-    importance: float | None = None
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    importance: float | None = Field(default=None, ge=0.0, le=1.0)
     reason: str
     status: MemoryCandidateStatus = MemoryCandidateStatus.PENDING
     created_at: str = Field(default_factory=_now_iso)
@@ -293,14 +285,6 @@ class MemoryCandidate(BaseModel):
             raise ValueError("候选记忆正文和原因不能为空")
         return value
 
-    @field_validator("confidence", "importance")
-    @classmethod
-    def _validate_score(cls, value: float | None) -> float | None:
-        """校验候选分数范围。"""
-        if value is not None and not 0.0 <= value <= 1.0:
-            raise ValueError("候选记忆分数必须在 0.0 到 1.0 之间")
-        return value
-
 
 class MemoryItemPatch(BaseModel):
     """长期记忆条目的部分更新。"""
@@ -309,8 +293,8 @@ class MemoryItemPatch(BaseModel):
     category: MemoryCategory | None = None
     kind: MemoryItemKind | None = None
     status: MemoryItemStatus | None = None
-    confidence: float | None = None
-    importance: float | None = None
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    importance: float | None = Field(default=None, ge=0.0, le=1.0)
     artifacts: list[MemoryArtifactRef] | None = None
     metadata: dict[str, Any] | None = None
 
@@ -322,14 +306,6 @@ class MemoryItemPatch(BaseModel):
         """校验更新正文不能是空白。"""
         if value is not None and not value.strip():
             raise ValueError("记忆正文不能为空")
-        return value
-
-    @field_validator("confidence", "importance")
-    @classmethod
-    def _validate_optional_score(cls, value: float | None) -> float | None:
-        """校验可选分数范围。"""
-        if value is not None and not 0.0 <= value <= 1.0:
-            raise ValueError("记忆分数必须在 0.0 到 1.0 之间")
         return value
 
 
@@ -357,18 +333,10 @@ class MemoryQuery(BaseModel):
     item_ids: list[str] = Field(default_factory=list)
     categories: list[MemoryCategory] = Field(default_factory=list)
     kinds: list[MemoryItemKind] = Field(default_factory=list)
-    limit: int = 10
+    limit: int = Field(default=10, gt=0, le=100)
     include_deleted: bool = False
 
     model_config = {"use_enum_values": False}
-
-    @field_validator("limit")
-    @classmethod
-    def _validate_limit(cls, value: int) -> int:
-        """校验并限制召回数量上限。"""
-        if value <= 0:
-            raise ValueError("记忆查询 limit 必须为正数")
-        return min(value, 100)
 
 
 class MemorySearchResult(BaseModel):
@@ -392,8 +360,8 @@ class MemoryWriteInput(BaseModel):
     source_type: MemorySourceType = MemorySourceType.SDK
     source_id: str = ""
     actor: MemoryActor = MemoryActor.SDK
-    confidence: float | None = None
-    importance: float | None = None
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    importance: float | None = Field(default=None, ge=0.0, le=1.0)
     artifacts: list[MemoryArtifactRef] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
 
@@ -405,14 +373,6 @@ class MemoryWriteInput(BaseModel):
         """校验写入正文与原因不能为空。"""
         if not value.strip():
             raise ValueError("记忆写入正文和原因不能为空")
-        return value
-
-    @field_validator("confidence", "importance")
-    @classmethod
-    def _validate_write_score(cls, value: float | None) -> float | None:
-        """校验写入分数范围。"""
-        if value is not None and not 0.0 <= value <= 1.0:
-            raise ValueError("记忆分数必须在 0.0 到 1.0 之间")
         return value
 
 

--- a/src/iris/memory/service.py
+++ b/src/iris/memory/service.py
@@ -149,7 +149,7 @@ class MemoryService:
         Returns:
             MemoryItem: 构造完整并被持久化后的权威长期记忆记录。
         """
-        item = MemoryItem(
+        item = MemoryItem.model_construct(
             scope=input.scope,
             text=input.text,
             category=input.category,

--- a/src/iris/memory/tools.py
+++ b/src/iris/memory/tools.py
@@ -80,17 +80,9 @@ class MemorySearchToolInput(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     query: str
-    limit: int = 8
+    limit: int = Field(default=8, gt=0, le=100)
     categories: list[MemoryCategory] = Field(default_factory=list)
     kinds: list[MemoryItemKind] = Field(default_factory=list)
-
-    @field_validator("limit")
-    @classmethod
-    def _validate_limit(cls, value: int) -> int:
-        """限制搜索返回数量。"""
-        if value <= 0:
-            raise ValueError("limit 必须为正数")
-        return min(value, 100)
 
 
 class MemoryListToolInput(BaseModel):
@@ -98,16 +90,8 @@ class MemoryListToolInput(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    limit: int = 50
+    limit: int = Field(default=50, gt=0, le=100)
     category: MemoryCategory | None = None
-
-    @field_validator("limit")
-    @classmethod
-    def _validate_limit(cls, value: int) -> int:
-        """限制列表返回数量。"""
-        if value <= 0:
-            raise ValueError("limit 必须为正数")
-        return min(value, 100)
 
 
 class MemoryGetToolInput(BaseModel):
@@ -168,7 +152,7 @@ class MemoryTool(BaseTool, Generic[InputT]):  # noqa: UP046
         context: ToolExecutionContext,
     ) -> ToolResult:
         """适配工具协议并调用具体记忆业务。"""
-        input_data = cast(InputT, self.input_type.model_validate(params))
+        input_data = cast(InputT, params)
         return await self._impl(input_data, context)
 
     @abstractmethod
@@ -210,7 +194,7 @@ class MemorySearchTool(MemoryTool[MemorySearchToolInput]):
             for scope in scopes:
                 results.extend(
                     self.service.recall(
-                        MemoryQuery(
+                        MemoryQuery.model_construct(
                             scope=scope,
                             text=params.query,
                             categories=params.categories,

--- a/src/iris/runtime/README.en.md
+++ b/src/iris/runtime/README.en.md
@@ -83,8 +83,9 @@ change public config, schemas, models, or exports.
 
 Only consecutive candidates share a window. STOP, HITL, preflight results,
 WRITE/EXECUTE/NETWORK/MCP/AGENT calls, unsafe calls, and classification failures are serial
-barriers; later calls cannot start across them. Every child still revalidates and records its own
-exact durable claim before entering the body. Bodies may finish out of order, while result
+barriers; later calls cannot start across them. The batch reuses its first typed tool plan. Before
+entering the body, each child refreshes permission and records its own exact durable claim without
+repeating schema validation. Bodies may finish out of order, while result
 messages, cursors, session history, checkpoints, and committed events advance only as the original
 ordinal prefix. The order of multiple `TOOL_CALL_CLAIMED` telemetry events is not contractual.
 

--- a/src/iris/runtime/README.md
+++ b/src/iris/runtime/README.md
@@ -82,8 +82,9 @@ callback 自身的异常只记录日志，不会覆盖 durable 结果。传入 `
 本次能力没有改变 public config、schema、model 或导出。
 
 窗口只覆盖连续候选。STOP、HITL、preflight result、WRITE/EXECUTE/NETWORK/MCP/AGENT，以及任一
-不安全或分类失败的调用都是串行屏障，后序调用不能跨过屏障启动。每个 child 在 body 前仍会
-独立 revalidate 并提交 exact durable claim；body 可以乱序结束，但 result message、cursor、
+不安全或分类失败的调用都是串行屏障，后序调用不能跨过屏障启动。整个 batch 复用首次生成的
+typed tool plan；每个 child 在 body 前只刷新 permission 并提交 exact durable claim，不重复
+schema validation。body 可以乱序结束，但 result message、cursor、
 session history、checkpoint 和 committed event 只按原始 ordinal 的连续前缀推进。多个
 `TOOL_CALL_CLAIMED` telemetry event 的先后顺序不是契约。
 

--- a/src/iris/runtime/commit.py
+++ b/src/iris/runtime/commit.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Protocol, Self
+from typing import Protocol
 
 from pydantic import (
     BaseModel,
@@ -17,13 +17,11 @@ from pydantic import (
     Field,
     ValidationInfo,
     field_validator,
-    model_validator,
 )
-from pydantic_core import PydanticSerializationError
 
 from ..exceptions import IrisRunConflictError, IrisRunStateError
 from ..hitl import HumanInteraction, HumanInteractionRequest, make_call_fingerprint
-from ..lifecycle import CheckpointResumability, SessionSnapshot, validate_json_safe
+from ..lifecycle import CheckpointResumability, SessionSnapshot
 from ..message import Msg
 from ..tools import PreparedToolCall, ToolEffectGuard, ToolResult
 from .models import RuntimeActivationInput, RuntimeCursor
@@ -35,16 +33,6 @@ class _FrozenCommitModel(BaseModel):
     """Required commit facts 的不可变模型基类。"""
 
     model_config = ConfigDict(extra="forbid", frozen=True, use_enum_values=False)
-
-    @model_validator(mode="after")
-    def _validate_json_safe_fact(self) -> Self:
-        """拒绝 required commit fact 中不可持久化的 live object。"""
-        try:
-            serialized = self.model_dump(mode="json")
-        except (PydanticSerializationError, TypeError, ValueError) as exc:
-            raise ValueError("required commit fact 必须是 JSON-safe") from exc
-        validate_json_safe(serialized, field_name="required commit fact")
-        return self
 
 
 class ModelStepReservation(_FrozenCommitModel):
@@ -85,11 +73,6 @@ class RuntimeToolCall(_FrozenCommitModel):
         if not normalized:
             raise ValueError(f"{info.field_name} 不能为空")
         return normalized
-
-    @field_validator("arguments")
-    @classmethod
-    def _validate_arguments(cls, value: dict[str, object]) -> dict[str, object]:
-        return validate_json_safe(value, field_name="arguments")
 
 
 class ToolCallClaim(_FrozenCommitModel):
@@ -206,7 +189,7 @@ def build_runtime_tool_call(
 ) -> RuntimeToolCall:
     """把一条 revalidated/preflight 调用转换为 durable tool fact。"""
     arguments: dict[str, object] = dict(
-        prepared.validated_params or prepared.tool_use.input
+        prepared.arguments if prepared.validated_input is not None else prepared.tool_use.input
     )
     fingerprint = make_call_fingerprint(
         session_id=activation.session_id,

--- a/src/iris/runtime/models.py
+++ b/src/iris/runtime/models.py
@@ -9,14 +9,9 @@ from enum import StrEnum
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
-from pydantic_core import PydanticSerializationError
 
 from ..hitl import HumanInteraction
-from ..lifecycle.models import (
-    RunErrorInfo,
-    RuntimeExecutionOptions,
-    validate_json_safe,
-)
+from ..lifecycle.models import RunErrorInfo, RuntimeExecutionOptions
 from ..message import Msg, ToolUseBlock
 from ..tools import ToolResult
 
@@ -50,16 +45,6 @@ class RuntimeCursor(_FrozenRuntimeModel):
     assistant_message: Msg | None = None
     read_state: dict[str, Any] | None = None
 
-    @field_validator("read_state")
-    @classmethod
-    def _validate_read_state(
-        cls,
-        value: dict[str, Any] | None,
-    ) -> dict[str, Any] | None:
-        if value is None:
-            return None
-        return validate_json_safe(value, field_name="read_state")
-
     @model_validator(mode="after")
     def _validate_position(self) -> RuntimeCursor:
         call_ids = [call.id for call in self.tool_calls]
@@ -92,11 +77,6 @@ class RuntimeCursor(_FrozenRuntimeModel):
                 raise ValueError("outcome_ready cursor 必须包含 assistant message")
             if self.next_tool_index != len(self.tool_calls):
                 raise ValueError("outcome_ready cursor 不能包含未提交工具调用")
-        try:
-            serialized = self.model_dump(mode="json")
-        except (PydanticSerializationError, TypeError, ValueError) as exc:
-            raise ValueError("runtime cursor 必须是 JSON-safe") from exc
-        validate_json_safe(serialized, field_name="runtime cursor")
         return self
 
 
@@ -154,14 +134,8 @@ class RuntimeActivationInput(_FrozenRuntimeModel):
                 raise ValueError("初始 recover activation 必须包含非空 input")
         elif self.input is not None:
             raise ValueError("非初始 recover activation 不能重复携带用户 input")
-        if self.interaction_projection is not None:
-            if self.cursor.position != "tool_batch":
-                raise ValueError("interaction projection 必须绑定 tool_batch cursor")
-            try:
-                projection = self.interaction_projection.model_dump(mode="json")
-            except (PydanticSerializationError, TypeError, ValueError) as exc:
-                raise ValueError("interaction projection 必须是 JSON-safe") from exc
-            validate_json_safe(projection, field_name="interaction projection")
+        if self.interaction_projection is not None and self.cursor.position != "tool_batch":
+            raise ValueError("interaction projection 必须绑定 tool_batch cursor")
         return self
 
 

--- a/src/iris/runtime/runtime.py
+++ b/src/iris/runtime/runtime.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any, cast
 
 from ..exceptions import (
@@ -24,6 +25,7 @@ from ..message import LLMRequest, Msg
 from ..tools import (
     CancellationSignal,
     PreparedToolCall,
+    ToolBatchPlan,
     ToolRegistryView,
     ToolResult,
 )
@@ -54,6 +56,14 @@ from .tool_bridge import ToolBridge
 
 _MAX_PARALLEL_TOOL_CALLS = 8
 _logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class _ModelStepAdvance:
+    """一次已提交模型步骤及其同进程工具计划。"""
+
+    cursor: RuntimeCursor
+    plan: ToolBatchPlan | None = None
 
 
 class AgentRuntime:
@@ -88,6 +98,7 @@ class AgentRuntime:
         )
         interaction_projection = activation.interaction_projection
         projection_validated = False
+        plan: ToolBatchPlan | None = None
 
         while True:
             # --- 2. 收口 activation 状态 ---
@@ -123,22 +134,25 @@ class AgentRuntime:
                 )
                 if isinstance(model_outcome, RuntimeActivationResult):
                     return model_outcome
-                cursor = model_outcome
+                cursor = model_outcome.cursor
+                plan = model_outcome.plan
+                projection_validated = False
                 continue
 
             # --- 4. 预检工具批次 ---
             # 为当前 assistant 消息重建执行计划，并校验恢复投影与 cursor 是否一致。
-            plan = self.environment.tool_bridge.preflight_once(
-                assistant_message=cast(Msg, cursor.assistant_message),
-                session_id=activation.session_id,
-                run_id=activation.run_id,
-                agent_id=self.environment.agent_config.name,
-                workspace_root=self.environment.workspace_root,
-                permission_mode=self.environment.agent_config.permissions.writes,
-                metadata={"activation_id": activation.activation_id},
-                tools_enabled=activation.options.include_tools,
-                cancellation=cancellation,
-            )
+            if plan is None:
+                plan = self.environment.tool_bridge.preflight_once(
+                    assistant_message=cast(Msg, cursor.assistant_message),
+                    session_id=activation.session_id,
+                    run_id=activation.run_id,
+                    agent_id=self.environment.agent_config.name,
+                    workspace_root=self.environment.workspace_root,
+                    permission_mode=self.environment.agent_config.permissions.writes,
+                    metadata={"activation_id": activation.activation_id},
+                    tools_enabled=activation.options.include_tools,
+                    cancellation=cancellation,
+                )
             if not projection_validated:
                 _validate_interaction_projection(
                     interaction_projection,
@@ -378,7 +392,7 @@ class AgentRuntime:
             await asyncio.gather(*tasks, return_exceptions=True)
             raise
 
-        result_slots: list[ToolResult | BaseException | None] = []
+        result_slots: list[ToolResult | BaseException] = []
         infrastructure_errors: list[tuple[int, BaseException]] = []
         for offset, task in enumerate(tasks):
             if task.cancelled():
@@ -418,8 +432,6 @@ class AgentRuntime:
             if isinstance(slot, BaseException):
                 interrupted = True
                 break
-            if slot is None:
-                raise IrisRunConflictError("并发工具窗口缺少已观察结果")
             _, prepared = window[offset]
             guard = guards[offset]
             tool_call = guard.call_for(prepared.tool_use.id) or build_runtime_tool_call(
@@ -528,8 +540,7 @@ class AgentRuntime:
             steering is not None
             and next_index == len(cursor.tool_calls)
             and not (
-                result.is_error
-                and activation.options.tool_error_policy is ToolErrorPolicy.STOP
+                result.is_error and activation.options.tool_error_policy is ToolErrorPolicy.STOP
             )
             and not _activation_cancelled(commits, cancellation)
             and not _deadline_expired(commits)
@@ -583,7 +594,7 @@ class AgentRuntime:
         commits: RuntimeCommitPort,
         cancellation: CancellationSignal,
         steering: RuntimeSteeringPort | None,
-    ) -> RuntimeCursor | RuntimeActivationResult:
+    ) -> _ModelStepAdvance | RuntimeActivationResult:
         """执行并 required commit 一次 provider step。"""
         snapshot = commits.load_session()
         if snapshot.session_id != activation.session_id:
@@ -679,17 +690,6 @@ class AgentRuntime:
                 outcome=RuntimeActivationOutcome.CANCELLED,
                 cursor=cursor,
             )
-        plan = self.environment.tool_bridge.preflight_once(
-            assistant_message=assistant,
-            session_id=activation.session_id,
-            run_id=activation.run_id,
-            agent_id=self.environment.agent_config.name,
-            workspace_root=self.environment.workspace_root,
-            permission_mode=self.environment.agent_config.permissions.writes,
-            metadata={"activation_id": activation.activation_id},
-            tools_enabled=activation.options.include_tools,
-            cancellation=cancellation,
-        )
         message_delta = (*turn_messages, assistant)
         read_state = _read_state_snapshot(
             self.environment.tool_bridge.read_state(activation.session_id)
@@ -747,7 +747,7 @@ class AgentRuntime:
                     activation=activation,
                     submission_id=claimed_input.submission_id,
                 )
-                return committed
+                return _ModelStepAdvance(cursor=committed)
 
             cursor_after = RuntimeCursor(
                 position="outcome_ready",
@@ -775,6 +775,17 @@ class AgentRuntime:
                 assistant_message=assistant,
             )
 
+        plan = self.environment.tool_bridge.preflight_once(
+            assistant_message=assistant,
+            session_id=activation.session_id,
+            run_id=activation.run_id,
+            agent_id=self.environment.agent_config.name,
+            workspace_root=self.environment.workspace_root,
+            permission_mode=self.environment.agent_config.permissions.writes,
+            metadata={"activation_id": activation.activation_id},
+            tools_enabled=activation.options.include_tools,
+            cancellation=cancellation,
+        )
         cursor_after = RuntimeCursor(
             position="tool_batch",
             step_index=cursor.step_index,
@@ -833,7 +844,7 @@ class AgentRuntime:
         )
         if committed != cursor_after:
             raise IrisRunConflictError("model-step commit 返回了意外 cursor")
-        return committed
+        return _ModelStepAdvance(cursor=committed, plan=plan)
 
     def _suspend_existing_batch(
         self,

--- a/src/iris/runtime/tool_bridge.py
+++ b/src/iris/runtime/tool_bridge.py
@@ -82,7 +82,7 @@ class ToolBridge:
                         preflight_result=_not_allowed_result(call),
                     )
                 )
-        return ToolBatchPlan(calls=calls)
+        return ToolBatchPlan(calls=tuple(calls))
 
     def read_state(self, session_id: str) -> Any | None:
         """返回 session 当前保存的文件读取状态。"""

--- a/src/iris/skill/README.en.md
+++ b/src/iris/skill/README.en.md
@@ -167,6 +167,11 @@ The package-level public surface is exactly:
 
 Frontmatter helpers, internal regular expressions, and `LoadSkillInput` are implementation details.
 
+Directory discovery is the sole owner of Skill-name regex checks and description
+normalization/truncation. `SkillMetadata` is a trusted projection of that scan, and configured
+`max_description_chars` directly controls the truncation limit. `SkillDiagnostic` is a frozen slots
+dataclass used only by discovery results.
+
 ## Maintenance and verification
 
 | Change | Main location | Tests |

--- a/src/iris/skill/README.md
+++ b/src/iris/skill/README.md
@@ -159,6 +159,10 @@ description 的变化同样会改变 fingerprint。更新配置或 Skill metadat
 
 frontmatter helper、内部正则和 `LoadSkillInput` 都是实现细节。
 
+目录扫描是 Skill name regex 与 description 规范化/截断的唯一 owner；`SkillMetadata` 是扫描结果
+的 trusted projection，配置的 `max_description_chars` 会直接决定截断上限。`SkillDiagnostic` 是
+仅在发现流程内传递的 frozen slots dataclass。
+
 ## 维护与验证
 
 | 修改内容 | 主要位置 | 对应测试 |

--- a/src/iris/skill/discovery.py
+++ b/src/iris/skill/discovery.py
@@ -148,9 +148,7 @@ def _scan_root(
             continue
 
         try:
-            has_skill_file = any(
-                child.name == SKILL_FILE_NAME for child in candidate.iterdir()
-            )
+            has_skill_file = any(child.name == SKILL_FILE_NAME for child in candidate.iterdir())
         except OSError as exc:
             diagnostics.append(
                 SkillDiagnostic(
@@ -220,24 +218,13 @@ def _load_skill(
     max_description_chars: int,
 ) -> SkillMetadata:
     """严格加载单个 Skill 目录并构造不含正文的元数据。"""
-    if _NAME_RE.fullmatch(skill_dir.name) is None:
-        raise IrisSkillFormatError(
-            "Skill 目录名必须是小写 kebab-case",
-            path=str(skill_dir.resolve(strict=False)),
-            name=skill_dir.name,
-        )
-
     resolved_workspace = workspace_root
     resolved_root = root
     resolved_skill_dir = skill_dir.resolve(strict=False)
 
     try:
         skill_file = next(
-            (
-                child
-                for child in skill_dir.iterdir()
-                if child.name == SKILL_FILE_NAME
-            ),
+            (child for child in skill_dir.iterdir() if child.name == SKILL_FILE_NAME),
             None,
         )
     except OSError as exc:
@@ -310,21 +297,17 @@ def _load_skill(
     raw_name = frontmatter.get("name")
     declared_name = None if raw_name is None else str(raw_name)
     extra_frontmatter = {
-        key: value
-        for key, value in frontmatter.items()
-        if key not in {"name", "description"}
+        key: value for key, value in frontmatter.items() if key not in {"name", "description"}
     }
     del _body
 
-    return SkillMetadata(
+    return SkillMetadata.model_construct(
         name=skill_dir.name,
         description=description,
         scope=scope,
         skill_file=resolved_skill_file,
         root_dir=resolved_skill_dir,
-        relative_skill_file=resolved_skill_file.relative_to(
-            resolved_workspace
-        ).as_posix(),
+        relative_skill_file=resolved_skill_file.relative_to(resolved_workspace).as_posix(),
         root_index=root_index,
         description_truncated=description_truncated,
         declared_name=declared_name,

--- a/src/iris/skill/models.py
+++ b/src/iris/skill/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
 from typing import Any
@@ -11,9 +12,6 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
-    ValidationInfo,
-    field_validator,
-    model_validator,
 )
 
 SKILL_FILE_NAME = "SKILL.md"
@@ -53,50 +51,15 @@ class SkillMetadata(BaseModel):
     declared_name: str | None = None
     extra_frontmatter: dict[str, Any] = Field(default_factory=dict)
 
-    @model_validator(mode="before")
-    @classmethod
-    def _normalize_description_field(cls, data: Any) -> Any:
-        if not isinstance(data, dict):
-            return data
-        description = data.get("description")
-        if not isinstance(description, str):
-            return data
-        normalized, truncated = _normalize_description(
-            description,
-            MAX_DESCRIPTION_CHARS,
-        )
-        values = dict(data)
-        values["description"] = normalized
-        values["description_truncated"] = bool(
-            values.get("description_truncated", False)
-        ) or truncated
-        return values
 
-    @field_validator("name")
-    @classmethod
-    def _validate_name(cls, value: str) -> str:
-        if _NAME_RE.fullmatch(value) is None:
-            raise ValueError("name 必须是小写 kebab-case")
-        return value
-
-
-class SkillDiagnostic(BaseModel):
+@dataclass(frozen=True, slots=True)
+class SkillDiagnostic:
     """Skill 发现期产生的结构化 warning。"""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
 
     code: str
     message: str
     path: Path | None = None
-    detail: dict[str, str] = Field(default_factory=dict)
-
-    @field_validator("code", "message")
-    @classmethod
-    def _validate_required_text(cls, value: str, info: ValidationInfo) -> str:
-        normalized = value.strip()
-        if not normalized:
-            raise ValueError(f"{info.field_name} 不能为空")
-        return normalized
+    detail: dict[str, str] = field(default_factory=dict)
 
 
 class SkillDiscoveryOptions(BaseModel):

--- a/src/iris/skill/tool.py
+++ b/src/iris/skill/tool.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -56,8 +56,7 @@ class LoadSkillTool(BaseTool):
         self.definition = ToolDefinition(
             name="load_skill",
             description=(
-                "按 catalog 中的 skill name 读取对应 SKILL.md 指令；"
-                "只返回 Markdown，不执行脚本"
+                "按 catalog 中的 skill name 读取对应 SKILL.md 指令；只返回 Markdown，不执行脚本"
             ),
             input_schema=schema_from_pydantic_model(LoadSkillInput),
             capabilities={ToolCapability.READ},
@@ -81,7 +80,7 @@ class LoadSkillTool(BaseTool):
         context: ToolExecutionContext,
     ) -> ToolResult:
         """复查 live path 后通过共享文件服务读取 Skill。"""
-        input_data = LoadSkillInput.model_validate(params)
+        input_data = cast(LoadSkillInput, params)
         try:
             metadata = self.registry.get(input_data.name)
         except IrisSkillNotFoundError:

--- a/src/iris/store/README.en.md
+++ b/src/iris/store/README.en.md
@@ -49,7 +49,10 @@ Mutations use `BEGIN IMMEDIATE` and load only the rows required to validate and 
 command. Run, session, checkpoint, tool-call, and interaction updates use revision, sequence, or
 version CAS predicates. Lane, activation, interaction, tool, and run changes use incremental writes
 in the same transaction, while events remain append-only. Any SQL failure causes a complete
-transaction rollback, so readers never observe half-committed facts. Schema v2 keeps only revision,
+transaction rollback, so readers never observe half-committed facts. Both stores share lifecycle
+typed-transition helpers: a mutation checks the affected phase, fence, and delta, then applies
+`model_copy(update=...)` to the validated model. Full `model_validate()` is reserved for
+load/recovery boundaries such as SQLite row decoding. Schema v2 keeps only revision,
 message count, and update time in `sessions`; messages append under contiguous ordinals in
 `session_messages`. A non-empty delta serializes and inserts only its own messages while advancing
 metadata with a revision-and-message-count CAS. Full `SessionSnapshot` reads still rebuild and

--- a/src/iris/store/README.md
+++ b/src/iris/store/README.md
@@ -42,6 +42,9 @@ Mutation 使用 `BEGIN IMMEDIATE`，只加载当前 command 校验和变更所�
 checkpoint、tool call 与 interaction 更新分别使用 revision、sequence 或 version CAS
 predicates；lane、activation、interaction、tool facts 与 run 在同一事务中增量写入，events
 保持 append-only。任一 SQL 失败都会触发完整 transaction rollback，不暴露半更新状态。
+两个 store 共用 lifecycle typed transition helper：mutation 先检查受影响的 phase/fence/delta，
+再对已验证模型应用 `model_copy(update=...)`。完整 `model_validate()` 只用于 SQLite row decode 等
+load/recovery 边界。
 schema v2 的 `sessions` 只保存 revision、message count 与更新时间；消息按连续 ordinal 追加到
 `session_messages`。非空 delta 只序列化并插入本次消息，同时以 revision + message count 双条件
 CAS 推进 metadata；完整 `SessionSnapshot` 读取仍按 ordinal 重建并校验 `1..message_count`。

--- a/src/iris/store/_terminal_closure.py
+++ b/src/iris/store/_terminal_closure.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 from ..exceptions import IrisRunStateError
 from ..lifecycle.models import RunToolCallRecord, ToolCallPhase
+from ..lifecycle.transitions import mark_tool_call_outcome_unknown
 from ..message.message import Msg
 from ..tools.base import ToolErrorInfo, ToolResult
 
@@ -23,14 +24,7 @@ def build_terminal_tool_closure(
 ) -> tuple[RunToolCallRecord, Msg]:
     """按 durable claim phase 构造 terminal tool fact 与模型可见 closer。"""
     if record.phase is ToolCallPhase.CLAIMED:
-        updated = RunToolCallRecord.model_validate(
-            record.model_dump()
-            | {
-                "phase": ToolCallPhase.OUTCOME_UNKNOWN,
-                "version": record.version + 1,
-                "updated_at": now,
-            }
-        )
+        updated = mark_tool_call_outcome_unknown(record, now=now)
         error = ToolErrorInfo(
             code="TOOL_OUTCOME_UNKNOWN",
             message=_OUTCOME_UNKNOWN_MESSAGE,

--- a/src/iris/store/in_memory.py
+++ b/src/iris/store/in_memory.py
@@ -13,7 +13,10 @@ from __future__ import annotations
 import json
 from bisect import bisect_right
 from copy import deepcopy
+from dataclasses import fields, is_dataclass
+from dataclasses import replace as dataclass_replace
 from datetime import datetime
+from enum import Enum
 from threading import RLock
 from typing import Any, Protocol
 
@@ -66,6 +69,15 @@ from ..lifecycle.store import (
     ResumeWaitingRun,
     RunCommit,
     SuspendRun,
+)
+from ..lifecycle.transitions import (
+    abandon_activation,
+    claim_tool_call,
+    commit_tool_call,
+    commit_tool_usage,
+    replace_run,
+    reserve_model_step,
+    settle_activation,
 )
 from ..message.message import Msg, TextBlock
 from ..tools.base import ToolErrorInfo, ToolResult
@@ -245,9 +257,8 @@ class InMemoryLifecycleStore:
                 status=ActivationStatus.ACTIVE,
                 started_at=command.now,
             )
-            rebound = RunCheckpoint.model_validate(
-                checkpoint.model_dump()
-                | {
+            rebound = checkpoint.model_copy(
+                update={
                     "sequence": checkpoint.sequence + 1,
                     "activation_id": activation.activation_id,
                 }
@@ -303,10 +314,7 @@ class InMemoryLifecycleStore:
             run = self._require_active(command)
             if run.usage.model_steps_reserved >= run.options.limits.max_model_steps:
                 return self._finish_budget_exhausted(run, command.now, command)
-            usage = RunUsage.model_validate(
-                run.usage.model_dump()
-                | {"model_steps_reserved": run.usage.model_steps_reserved + 1}
-            )
+            usage = reserve_model_step(run.usage)
             checkpoint = self._require_checkpoint(run.run_id).model_copy(
                 update={"model_steps_reserved": usage.model_steps_reserved}
             )
@@ -413,15 +421,10 @@ class InMemoryLifecycleStore:
                 raise IrisRunStateError("只有 prepared tool call 可以 claim")
             if run.cancellation_requested_at is not None:
                 raise IrisRunStateError("已请求取消的 run 不接受新的 tool call claim")
-            claimed = RunToolCallRecord.model_validate(
-                tool_call.model_dump()
-                | {
-                    "phase": ToolCallPhase.CLAIMED,
-                    "claim_activation_id": command.activation_id,
-                    "version": tool_call.version + 1,
-                    "updated_at": command.now,
-                    "claimed_at": command.now,
-                }
+            claimed = claim_tool_call(
+                tool_call,
+                activation_id=command.activation_id,
+                now=command.now,
             )
             sequence = run.last_event_sequence + 1
             updated = self._replace_run(
@@ -490,20 +493,12 @@ class InMemoryLifecycleStore:
                 next_session.revision,
                 run.usage,
             )
-            committed_call = RunToolCallRecord.model_validate(
-                tool_call.model_dump()
-                | {
-                    "phase": ToolCallPhase.COMMITTED,
-                    "result": command.result,
-                    "version": tool_call.version + 1,
-                    "updated_at": command.now,
-                    "committed_at": command.now,
-                }
+            committed_call = commit_tool_call(
+                tool_call,
+                result=command.result,
+                now=command.now,
             )
-            usage = RunUsage.model_validate(
-                run.usage.model_dump()
-                | {"tool_calls_committed": run.usage.tool_calls_committed + 1}
-            )
+            usage = commit_tool_usage(run.usage)
             sequence = run.last_event_sequence + 1
             updated = self._replace_run(
                 run,
@@ -585,13 +580,10 @@ class InMemoryLifecycleStore:
                 update={"interaction_id": interaction.interaction_id}
             )
             activation = self._require_activation(command.activation_id)
-            settled = ActivationRecord.model_validate(
-                activation.model_dump()
-                | {
-                    "status": ActivationStatus.SETTLED,
-                    "outcome": ActivationOutcome.SUSPENDED,
-                    "ended_at": command.now,
-                }
+            settled = settle_activation(
+                activation,
+                outcome=ActivationOutcome.SUSPENDED,
+                ended_at=command.now,
             )
             sequence = run.last_event_sequence + 1
             updated = self._replace_run(
@@ -873,13 +865,10 @@ class InMemoryLifecycleStore:
             if run.phase is RunPhase.ACTIVE:
                 activation = self._require_activation(run.current_activation_id)
                 outcome = self._activation_outcome(command.stop_reason)
-                settled = ActivationRecord.model_validate(
-                    activation.model_dump()
-                    | {
-                        "status": ActivationStatus.SETTLED,
-                        "outcome": outcome,
-                        "ended_at": command.now,
-                    }
+                settled = settle_activation(
+                    activation,
+                    outcome=outcome,
+                    ended_at=command.now,
                 )
             else:
                 activation = None
@@ -994,13 +983,10 @@ class InMemoryLifecycleStore:
                 if command.recovery_disposition is RecoveryDisposition.OUTCOME_UNKNOWN
                 else ActivationOutcome.RECOVERED
             )
-            abandoned = ActivationRecord.model_validate(
-                activation.model_dump()
-                | {
-                    "status": ActivationStatus.ABANDONED,
-                    "outcome": abandoned_outcome,
-                    "ended_at": command.now,
-                }
+            abandoned = abandon_activation(
+                activation,
+                outcome=abandoned_outcome,
+                ended_at=command.now,
             )
             first_sequence = run.last_event_sequence + 1
             abandoned_event = self._event(
@@ -1151,9 +1137,8 @@ class InMemoryLifecycleStore:
                     status=ActivationStatus.ACTIVE,
                     started_at=command.now,
                 )
-                rebound = RunCheckpoint.model_validate(
-                    checkpoint.model_dump()
-                    | {
+                rebound = checkpoint.model_copy(
+                    update={
                         "sequence": checkpoint.sequence + 1,
                         "activation_id": activation_next.activation_id,
                         "resumability": CheckpointResumability.SAFE,
@@ -1367,7 +1352,7 @@ class InMemoryLifecycleStore:
 
     @staticmethod
     def _replace_run(run: RunRecord, **changes: Any) -> RunRecord:
-        return RunRecord.model_validate(run.model_dump() | changes)
+        return replace_run(run, **changes)
 
     @staticmethod
     def _event(
@@ -1577,13 +1562,10 @@ class InMemoryLifecycleStore:
         command: ReserveModelStep,
     ) -> RunCommit:
         activation = self._require_activation(run.current_activation_id)
-        settled = ActivationRecord.model_validate(
-            activation.model_dump()
-            | {
-                "status": ActivationStatus.SETTLED,
-                "outcome": ActivationOutcome.FAILED,
-                "ended_at": now,
-            }
+        settled = settle_activation(
+            activation,
+            outcome=ActivationOutcome.FAILED,
+            ended_at=now,
         )
         sequence = run.last_event_sequence + 1
         updated = self._replace_run(
@@ -1619,11 +1601,11 @@ class InMemoryLifecycleStore:
         return self._store_replay("reserve_model_step", command, commit)
 
     @staticmethod
-    def _replay_key(operation: str, command: BaseModel) -> str:
-        payload = command.model_dump(mode="json")
+    def _replay_key(operation: str, command: object) -> str:
+        payload = _jsonable(command)
         return f"{operation}:{json.dumps(payload, allow_nan=False, sort_keys=True)}"
 
-    def _load_replay(self, operation: str, command: BaseModel) -> RunCommit | None:
+    def _load_replay(self, operation: str, command: object) -> RunCommit | None:
         replay = self._replays.get(self._replay_key(operation, command))
         if replay is None:
             return None
@@ -1635,28 +1617,43 @@ class InMemoryLifecycleStore:
             if replay.interaction is not None
             else None
         )
-        current = replay.model_copy(
-            deep=True,
-            update={
-                "run": deepcopy(run),
-                "session": deepcopy(session),
-                "checkpoint": deepcopy(checkpoint),
-                "interaction": deepcopy(interaction),
-                "events": (),
-                "result": deepcopy(self._results.get(run.run_id)),
-            },
+        current = dataclass_replace(
+            replay,
+            run=deepcopy(run),
+            session=deepcopy(session),
+            checkpoint=deepcopy(checkpoint),
+            interaction=deepcopy(interaction),
+            events=(),
+            result=deepcopy(self._results.get(run.run_id)),
         )
         return deepcopy(current)
 
     def _store_replay(
         self,
         operation: str,
-        command: BaseModel,
+        command: object,
         commit: RunCommit,
     ) -> RunCommit:
         isolated = deepcopy(commit)
         self._replays[self._replay_key(operation, command)] = isolated
         return deepcopy(isolated)
+
+
+def _jsonable(value: object) -> object:
+    """把 replay key 的内部 command 投影为稳定 JSON 值。"""
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json")
+    if is_dataclass(value) and not isinstance(value, type):
+        return {item.name: _jsonable(getattr(value, item.name)) for item in fields(value)}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
 
 
 __all__ = ["InMemoryLifecycleStore"]

--- a/src/iris/store/sqlite.py
+++ b/src/iris/store/sqlite.py
@@ -6,7 +6,10 @@ import json
 import sqlite3
 from collections.abc import Callable
 from copy import deepcopy
+from dataclasses import fields, is_dataclass
+from dataclasses import replace as dataclass_replace
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
 from threading import RLock
 from typing import Any, Protocol, TypeVar
@@ -67,12 +70,21 @@ from ..lifecycle.store import (
     RunCommit,
     SuspendRun,
 )
+from ..lifecycle.transitions import (
+    abandon_activation,
+    claim_tool_call,
+    commit_tool_call,
+    commit_tool_usage,
+    replace_run,
+    reserve_model_step,
+    settle_activation,
+)
 from ..message.message import Msg, TextBlock
 from ..tools.base import ToolErrorInfo, ToolResult
 from ._sqlite_schema import create_schema, require_exact_schema
 from ._terminal_closure import build_terminal_tool_closure
 
-_CommandT = TypeVar("_CommandT", bound=BaseModel)
+_CommandT = TypeVar("_CommandT")
 _ReadT = TypeVar("_ReadT")
 _RESPONSE_ADAPTER = TypeAdapter(HumanInteractionResponse)
 
@@ -434,7 +446,7 @@ class SQLiteStore:
         self,
         connection: sqlite3.Connection,
         operation: str,
-        command: BaseModel,
+        command: object,
     ) -> RunCommit | None:
         """把 process-local replay 刷新为当前 durable facts。"""
         replay = self._replays.get(_replay_key(operation, command))
@@ -464,16 +476,14 @@ class SQLiteStore:
             if replay.interaction is not None
             else None
         )
-        return replay.model_copy(
-            deep=True,
-            update={
-                "run": run,
-                "session": session,
-                "checkpoint": checkpoint,
-                "interaction": interaction,
-                "events": (),
-                "result": self._select_result(connection, run, operation=operation),
-            },
+        return dataclass_replace(
+            replay,
+            run=run,
+            session=session,
+            checkpoint=checkpoint,
+            interaction=interaction,
+            events=(),
+            result=self._select_result(connection, run, operation=operation),
         )
 
     def _require_run(
@@ -713,9 +723,8 @@ class SQLiteStore:
             status=ActivationStatus.ACTIVE,
             started_at=command.now,
         )
-        rebound = RunCheckpoint.model_validate(
-            checkpoint.model_dump()
-            | {
+        rebound = checkpoint.model_copy(
+            update={
                 "sequence": checkpoint.sequence + 1,
                 "activation_id": activation.activation_id,
             }
@@ -780,13 +789,10 @@ class SQLiteStore:
                 run.current_activation_id,
                 operation=operation,
             )
-            settled = ActivationRecord.model_validate(
-                activation.model_dump()
-                | {
-                    "status": ActivationStatus.SETTLED,
-                    "outcome": ActivationOutcome.FAILED,
-                    "ended_at": command.now,
-                }
+            settled = settle_activation(
+                activation,
+                outcome=ActivationOutcome.FAILED,
+                ended_at=command.now,
             )
             sequence = run.last_event_sequence + 1
             updated = _replace_run(
@@ -824,9 +830,7 @@ class SQLiteStore:
                 result=project_result(updated),
             )
 
-        usage = RunUsage.model_validate(
-            run.usage.model_dump() | {"model_steps_reserved": run.usage.model_steps_reserved + 1}
-        )
+        usage = reserve_model_step(run.usage)
         updated_checkpoint = checkpoint.model_copy(
             update={"model_steps_reserved": usage.model_steps_reserved}
         )
@@ -979,15 +983,10 @@ class SQLiteStore:
         if run.cancellation_requested_at is not None:
             raise IrisRunStateError("已请求取消的 run 不接受新的 tool call claim")
         checkpoint = self._require_checkpoint(connection, run.run_id, operation=operation)
-        claimed = RunToolCallRecord.model_validate(
-            tool_call.model_dump()
-            | {
-                "phase": ToolCallPhase.CLAIMED,
-                "claim_activation_id": command.activation_id,
-                "version": tool_call.version + 1,
-                "updated_at": command.now,
-                "claimed_at": command.now,
-            }
+        claimed = claim_tool_call(
+            tool_call,
+            activation_id=command.activation_id,
+            now=command.now,
         )
         sequence = run.last_event_sequence + 1
         updated = _replace_run(
@@ -1079,19 +1078,12 @@ class SQLiteStore:
             next_session_revision,
             run.usage,
         )
-        committed_call = RunToolCallRecord.model_validate(
-            tool_call.model_dump()
-            | {
-                "phase": ToolCallPhase.COMMITTED,
-                "result": command.result,
-                "version": tool_call.version + 1,
-                "updated_at": command.now,
-                "committed_at": command.now,
-            }
+        committed_call = commit_tool_call(
+            tool_call,
+            result=command.result,
+            now=command.now,
         )
-        usage = RunUsage.model_validate(
-            run.usage.model_dump() | {"tool_calls_committed": run.usage.tool_calls_committed + 1}
-        )
+        usage = commit_tool_usage(run.usage)
         sequence = run.last_event_sequence + 1
         updated = _replace_run(
             run,
@@ -1210,13 +1202,10 @@ class SQLiteStore:
             command.activation_id,
             operation=operation,
         )
-        settled = ActivationRecord.model_validate(
-            activation.model_dump()
-            | {
-                "status": ActivationStatus.SETTLED,
-                "outcome": ActivationOutcome.SUSPENDED,
-                "ended_at": command.now,
-            }
+        settled = settle_activation(
+            activation,
+            outcome=ActivationOutcome.SUSPENDED,
+            ended_at=command.now,
         )
         sequence = run.last_event_sequence + 1
         updated = _replace_run(
@@ -1649,13 +1638,10 @@ class SQLiteStore:
                 run.current_activation_id,
                 operation=operation,
             )
-            settled = ActivationRecord.model_validate(
-                activation.model_dump()
-                | {
-                    "status": ActivationStatus.SETTLED,
-                    "outcome": _activation_outcome(command.stop_reason),
-                    "ended_at": command.now,
-                }
+            settled = settle_activation(
+                activation,
+                outcome=_activation_outcome(command.stop_reason),
+                ended_at=command.now,
             )
         else:
             activation = None
@@ -1800,13 +1786,10 @@ class SQLiteStore:
             if command.recovery_disposition is RecoveryDisposition.OUTCOME_UNKNOWN
             else ActivationOutcome.RECOVERED
         )
-        abandoned = ActivationRecord.model_validate(
-            activation.model_dump()
-            | {
-                "status": ActivationStatus.ABANDONED,
-                "outcome": abandoned_outcome,
-                "ended_at": command.now,
-            }
+        abandoned = abandon_activation(
+            activation,
+            outcome=abandoned_outcome,
+            ended_at=command.now,
         )
         first_sequence = run.last_event_sequence + 1
         abandoned_event = _make_event(
@@ -1965,9 +1948,8 @@ class SQLiteStore:
                 status=ActivationStatus.ACTIVE,
                 started_at=command.now,
             )
-            rebound = RunCheckpoint.model_validate(
-                checkpoint.model_dump()
-                | {
+            rebound = checkpoint.model_copy(
+                update={
                     "sequence": checkpoint.sequence + 1,
                     "activation_id": activation_next.activation_id,
                     "resumability": CheckpointResumability.SAFE,
@@ -3150,8 +3132,8 @@ def _make_event(
 
 
 def _replace_run(run: RunRecord, **changes: Any) -> RunRecord:
-    """以领域模型验证后的字段替换构造新 run。"""
-    return RunRecord.model_validate(run.model_dump() | changes)
+    """应用已经过 store delta 检查的字段替换。"""
+    return replace_run(run, **changes)
 
 
 def _validate_checkpoint_replacement(
@@ -3229,8 +3211,8 @@ def _activation_outcome(stop_reason: RunStopReason) -> ActivationOutcome:
     }.get(stop_reason, ActivationOutcome.FAILED)
 
 
-def _replay_key(operation: str, command: BaseModel) -> str:
-    payload = command.model_dump(mode="json")
+def _replay_key(operation: str, command: object) -> str:
+    payload = _jsonable(command)
     return f"{operation}:{json.dumps(payload, allow_nan=False, sort_keys=True)}"
 
 
@@ -3239,10 +3221,7 @@ def _stored_activation_outcome(activation: ActivationRecord) -> str | None:
 
 
 def _dump_json(value: object) -> str:
-    if isinstance(value, BaseModel):
-        value = value.model_dump(mode="json")
-    elif isinstance(value, list) and value and isinstance(value[0], BaseModel):
-        value = [item.model_dump(mode="json") for item in value]
+    value = _jsonable(value)
     return json.dumps(
         value,
         allow_nan=False,
@@ -3250,6 +3229,23 @@ def _dump_json(value: object) -> str:
         separators=(",", ":"),
         sort_keys=True,
     )
+
+
+def _jsonable(value: object) -> object:
+    """把 durable/replay 输入投影为严格 JSON 值。"""
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json")
+    if is_dataclass(value) and not isinstance(value, type):
+        return {item.name: _jsonable(getattr(value, item.name)) for item in fields(value)}
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
 
 
 def _load_json(value: str) -> Any:

--- a/src/iris/tools/README.en.md
+++ b/src/iris/tools/README.en.md
@@ -81,11 +81,14 @@ middleware, and open-circuit failures to stable error codes. `execute_many()` ru
 read-only concurrency-safe calls concurrently and serializes writes or unsafe calls while preserving
 result order and shared file read state. Classification failure conservatively falls back to serial.
 
-`prepare_many()` performs registry lookup, validation, and policy checks without running middleware,
-the breaker, artifact persistence, or tool side effects. It returns `PreparedToolCall` objects and a
-human request where required. `execute_prepared()` begins a new stage, revalidates current state,
-accepts an approval only for the exact tool-call ID, and optionally accepts a `ToolEffectGuard`.
-Historical approval never overrides current deny, schema, workspace, or stale-read checks.
+`register(tool)` adds a `BaseTool` and raises a validation error on name or alias conflicts.
+`prepare_many()` performs registry lookup, input-schema validation, and the initial policy check
+without running middleware, the breaker, artifact persistence, or tool side effects. Each
+`PreparedToolCall` retains both typed `validated_input` and normalized `arguments`. Runtime reuses
+that plan for the complete tool batch. `execute_prepared()` refreshes permission only; it does not
+repeat registry lookup, schema validation, or a typed-model-to-dict round trip. It accepts approval
+only for the exact tool-call ID and optionally accepts a `ToolEffectGuard`. Historical approval
+never overrides current deny, workspace, or stale-read checks.
 
 `PermissionPolicy.fingerprint_payload()` is the lifecycle resumability contract for permission
 state. It must return deterministic JSON-safe data; custom policies must implement it explicitly
@@ -111,7 +114,7 @@ The blocking I/O in `read_file`, `list_files`, and `grep_search` runs in worker 
 and `edit_file` remain inline. Workers never mutate shared `ReadFileState`. A read returns an
 immutable `ReadFileRecord` observation that the event loop merges only after a successful await.
 
-`ToolExecutor` provides classification, revalidation, and per-call execution primitives only. The
+`ToolExecutor` provides classification, permission refresh, and per-call execution primitives only. The
 lifecycle active path layers a fixed internal runtime window bound of 8 over those primitives.
 Only consecutive read-only and concurrency-safe calls can enter a window; STOP, HITL, preflight
 results, and unsafe calls remain barriers. Every call keeps its own durable claim. Body completion

--- a/src/iris/tools/README.md
+++ b/src/iris/tools/README.md
@@ -105,7 +105,7 @@ tool_obj = registry.register_function(
 
 公共方法：
 
-- `register(tool, on_conflict="raise")`: 注册 `BaseTool` 实例；当前只支持 `raise` 冲突策略。
+- `register(tool)`: 注册 `BaseTool` 实例；名称或别名冲突时直接抛出校验错误。
 - `register_function(func, ...)`: 创建 `CallableTool` 并注册，支持 `name`、`description`、`input_model`、`capabilities`、`group`、`deferred`、`preset_kwargs`、`examples`、`tags`、`version`、`deprecated`、`deprecation_message`、`execution_mode`、`concurrency_safe`。显式参数优先于 `@tool` 元数据。
 - `get(name)`: 按主名称或别名获取工具，未找到时抛出工具不存在错误。
 - `view(include_groups=None, allow=None, deny=None)`: 创建只读过滤视图。
@@ -139,18 +139,17 @@ executor = ToolExecutor(
 - `prepare_many(tool_uses, context)`: 无副作用预检完整批次，返回 `ToolBatchPlan` 与
   `PreparedToolCall`；需要人工介入时保存统一的 `HumanInteractionRequest(tool_call, prompt)`，
   不会运行 middleware、circuit breaker、artifact 或工具本体。
-- `execute_prepared(prepared, context, approved_tool_call_id=None, effect_guard=None)`: 重新校验
-  当前状态后执行一条预检调用；lifecycle runtime 会注入 required effect guard。
+- `execute_prepared(prepared, context, approved_tool_call_id=None, effect_guard=None)`: 刷新当前
+  permission 后执行一条已验证调用；lifecycle runtime 会注入 required effect guard。
 
-预检阶段由唯一 `_prepare_call()` 完成 registry lookup、输入校验和 policy check，不运行工具
-生命周期。`execute_many()` 按输入顺序流式 prepare，每条调用在当前执行阶段只 lookup、校验和
-鉴权一次，再使用 `PreparedToolCall.tool` 与 `validated_params` 判断连续只读并发批次；
-classifier 异常会保守降级为串行执行。`execute_prepared()` 属于新的恢复执行阶段，因此会重新
-`_prepare_call()`，再按 `preflight_result` / `DENY`、human protocol guard、精确 approve 的
-优先级授权；通过后依次检查 circuit breaker、cancellation、effect guard、cancellation，随后才
-进入 middleware `before_call` → `tool.arun()` → artifact → middleware after hooks → breaker
-记录。guard 失败时不会进入任何工具 effect；claim 后取消会作为独立控制流向 runtime 传播。
-一次阶段内 policy 只检查一次，历史 approve 不能覆盖当前 `DENY`。直接使用低层 executor 时
+预检阶段由唯一 `_prepare_call()` 完成 registry lookup、输入 schema 校验和初次 policy check，
+并在 `PreparedToolCall` 中同时保留 typed `validated_input` 与供 middleware/fingerprint 使用的
+`arguments`。Runtime 在同一 tool batch 内复用该 plan；`execute_prepared()` 只刷新 permission，
+不会再次 lookup、降级为 dict 或重复 schema 校验。刷新后按 `preflight_result` / `DENY`、human
+protocol guard、精确 approve 的优先级授权；通过后依次检查 circuit breaker、cancellation、
+effect guard、cancellation，随后才进入 middleware `before_call` → `tool.arun()` → artifact →
+middleware after hooks → breaker 记录。guard 失败时不会进入任何工具 effect；claim 后取消会
+作为独立控制流向 runtime 传播。历史 approve 不能覆盖当前 `DENY`。直接使用低层 executor 时
 guard 可选；lifecycle 路径通过 `ToolBridge` 强制提供 guard。
 
 并发 context copy 会共享原始 `read_state` 和 `cancellation` live object；signal 不会进入
@@ -159,7 +158,7 @@ guard 可选；lifecycle 路径通过 `ToolBridge` 强制提供 guard。
 
 `read_file`、`list_files` 和 `grep_search` 的阻塞文件 I/O 在 worker thread 中运行；`write_file` 与 `edit_file` 仍保持 inline。worker 不修改共享 `ReadFileState`：`read_file` 返回不可变的 `ReadFileRecord` observation，await 成功后由 event loop 合并。因此并发只读批次仍共享调用方的完整读取状态，同一次 `execute_many()` 内的 `read_file -> edit_file/write_file` 能延续读后写校验。
 
-`ToolExecutor` 只提供分类、重校验和单调用执行原语；lifecycle active path 由 runtime 在它之上
+`ToolExecutor` 只提供分类、permission refresh 和单调用执行原语；lifecycle active path 由 runtime 在它之上
 使用固定内部上限 8 的窗口。只有连续 read-only + concurrency-safe 调用可以进入窗口；STOP、
 HITL、preflight result 与 unsafe 调用保持屏障语义。每个调用仍有自己的 durable claim，body
 完成顺序不决定 result 顺序，claim telemetry 顺序也不是 ordinal 契约。未声明的同步 callable

--- a/src/iris/tools/builtin/file.py
+++ b/src/iris/tools/builtin/file.py
@@ -21,7 +21,7 @@ from itertools import islice
 from pathlib import Path
 from typing import Any, ClassVar, Generic, TypeVar, cast
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from ...exceptions import IrisToolExecutionError, IrisToolValidationError
 from ...message import TextBlock
@@ -96,25 +96,9 @@ class ReadFileInput(BaseModel):
     """
 
     file_path: str
-    offset: int | None = None
-    limit: int | None = None
+    offset: int | None = Field(default=None, ge=0)
+    limit: int | None = Field(default=None, ge=0, le=1000)
     with_line_numbers: bool = False
-
-    @field_validator("offset", "limit")
-    @classmethod
-    def _validate_non_negative(cls, value: int | None) -> int | None:
-        """校验分页参数非负。"""
-        if value is not None and value < 0:
-            raise ValueError("offset/limit 必须非负")
-        return value
-
-    @field_validator("limit")
-    @classmethod
-    def _validate_limit(cls, value: int | None) -> int | None:
-        """限制单次读取行数。"""
-        if value is not None and value > 1000:
-            raise ValueError("limit 不能超过 1000")
-        return value
 
 
 class ListFilesInput(BaseModel):
@@ -128,15 +112,7 @@ class ListFilesInput(BaseModel):
 
     path: str = "."
     pattern: str | None = None
-    max_results: int = 200
-
-    @field_validator("max_results")
-    @classmethod
-    def _validate_max_results(cls, value: int) -> int:
-        """限制最大结果数。"""
-        if value < 0 or value > 1000:
-            raise ValueError("max_results 必须在 0..1000 范围内")
-        return value
+    max_results: int = Field(default=200, ge=0, le=1000)
 
 
 class GrepSearchInput(BaseModel):
@@ -150,15 +126,7 @@ class GrepSearchInput(BaseModel):
 
     pattern: str
     path: str = "."
-    max_results: int = 200
-
-    @field_validator("max_results")
-    @classmethod
-    def _validate_max_results(cls, value: int) -> int:
-        """限制最大结果数。"""
-        if value < 0 or value > 1000:
-            raise ValueError("max_results 必须在 0..1000 范围内")
-        return value
+    max_results: int = Field(default=200, ge=0, le=1000)
 
 
 class WriteFileInput(BaseModel):
@@ -658,7 +626,7 @@ class FileTool(BaseTool, Generic[InputT]):  # noqa: UP046
         Returns:
             ToolResult: 可转换为模型消息的工具结果。
         """
-        input_data = cast(InputT, self.input_type.model_validate(params))
+        input_data = cast(InputT, params)
         return await self._impl(input_data, context)
 
     # endregion

--- a/src/iris/tools/builtin/human.py
+++ b/src/iris/tools/builtin/human.py
@@ -65,13 +65,12 @@ class AskQuestionTool(BaseTool):
     def build_interaction_prompt(
         self,
         *,
-        params: AskQuestionInput | dict[str, Any],
+        params: AskQuestionInput,
     ) -> QuestionPrompt:
         """将已验证输入转换为向人展示的问题。"""
-        input_data = AskQuestionInput.model_validate(params)
-        return QuestionPrompt(
-            question=input_data.question,
-            options=input_data.options,
+        return QuestionPrompt.model_construct(
+            question=params.question,
+            options=params.options,
         )
 
     async def arun(
@@ -80,8 +79,7 @@ class AskQuestionTool(BaseTool):
         context: ToolExecutionContext,
     ) -> ToolResult:
         """拒绝绕过 runtime 直接执行 human question。"""
-        del context
-        AskQuestionInput.model_validate(params)
+        del params, context
         raise IrisHITLError("HITL_PROTOCOL_ERROR: ask_question 必须由 runtime 处理")
 
 

--- a/src/iris/tools/decorators.py
+++ b/src/iris/tools/decorators.py
@@ -15,12 +15,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from ..exceptions import IrisToolValidationError
-from .base import (
-    CallableExecutionMode,
-    ToolCapability,
-    _validated_callable_execution_mode,
-)
+from .base import CallableExecutionMode, ToolCapability
 
 # endregion
 
@@ -83,10 +78,6 @@ def tool(
         ...     return "content"
     """
 
-    validated_mode = _validated_callable_execution_mode(execution_mode)
-    if concurrency_safe is not None and not isinstance(concurrency_safe, bool):
-        raise IrisToolValidationError("callable concurrency_safe 必须是 bool")
-
     def decorator(func: F) -> F:
         func.__dict__["iris_tool_name"] = name
         func.__dict__["iris_tool_description"] = description
@@ -99,8 +90,8 @@ def tool(
         func.__dict__["iris_tool_version"] = version
         func.__dict__["iris_tool_deprecated"] = deprecated
         func.__dict__["iris_tool_deprecation_message"] = deprecation_message
-        if validated_mode is not None:
-            func.__dict__["iris_tool_execution_mode"] = validated_mode
+        if execution_mode is not None:
+            func.__dict__["iris_tool_execution_mode"] = execution_mode
         if concurrency_safe is not None:
             func.__dict__["iris_tool_concurrency_safe"] = concurrency_safe
         if registry is not None:

--- a/src/iris/tools/discovery.py
+++ b/src/iris/tools/discovery.py
@@ -10,9 +10,9 @@ import json
 import math
 import re
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 
 from ..exceptions import IrisToolValidationError
 from ..message import TextBlock
@@ -43,7 +43,16 @@ class ToolSearchInput(BaseModel):
 
     query: str
     include_groups: list[str] | None = None
-    limit: int = 10
+    limit: int = Field(default=10, gt=0, le=50)
+
+    @field_validator("query")
+    @classmethod
+    def _validate_query(cls, value: str) -> str:
+        """规范化并拒绝空白查询。"""
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("query 不能为空")
+        return normalized
 
     def normalized_groups(self) -> set[str] | None:
         """返回去重后的组过滤集合。
@@ -226,7 +235,11 @@ class ToolSearchTool(BaseTool):
             input_schema={
                 "type": "object",
                 "properties": {
-                    "query": {"type": "string", "description": "搜索关键词。"},
+                    "query": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "搜索关键词。",
+                    },
                     "include_groups": {
                         "type": "array",
                         "items": {"type": "string"},
@@ -235,6 +248,8 @@ class ToolSearchTool(BaseTool):
                     "limit": {
                         "type": "integer",
                         "default": 10,
+                        "minimum": 1,
+                        "maximum": 50,
                         "description": "最大返回数量。",
                     },
                 },
@@ -289,11 +304,6 @@ class ToolSearchTool(BaseTool):
         except ValueError as exc:
             raise IrisToolValidationError("tool_search 参数校验失败", error=str(exc)) from exc
 
-        if not value.query.strip():
-            raise IrisToolValidationError("tool_search query 不能为空")
-        if value.limit < 1:
-            raise IrisToolValidationError("tool_search limit 必须大于 0")
-
         return value
 
     async def arun(
@@ -311,10 +321,7 @@ class ToolSearchTool(BaseTool):
             ToolResult: 包含检索出的候选工具摘要组成的成功负载结构。
         """
         del context
-        if isinstance(params, ToolSearchInput):
-            search_input = params
-        else:
-            search_input = ToolSearchInput.model_validate(params)
+        search_input = cast(ToolSearchInput, params)
 
         matches = self.registry.search_deferred(
             search_input.query,
@@ -367,12 +374,10 @@ def _validated_query(query: str, limit: int) -> tuple[str, dict[str, float], int
         IrisToolValidationError: 如果最终词汇全为空则抛异常。
     """
     normalized_query = query.strip().lower()
-    if not normalized_query:
-        raise IrisToolValidationError("tool_search query 不能为空")
     query_terms = _token_weights(normalized_query)
     if not query_terms:
         raise IrisToolValidationError("tool_search query 必须包含可搜索文本")
-    return normalized_query, query_terms, min(max(limit, 1), 50)
+    return normalized_query, query_terms, limit
 
 
 def _bm25_score(

--- a/src/iris/tools/executor.py
+++ b/src/iris/tools/executor.py
@@ -15,9 +15,10 @@ import asyncio
 import inspect
 import re
 from collections.abc import Awaitable, Sequence
+from dataclasses import dataclass, field, replace
 from typing import Any, Protocol, cast
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ValidationError
 
 from ..exceptions import (
     IrisCancellationRequestedError,
@@ -58,23 +59,24 @@ class ToolEffectGuard(Protocol):
         """仅在 durable effect claim 成功后返回。"""
 
 
-class PreparedToolCall(BaseModel):
+@dataclass(frozen=True, slots=True)
+class PreparedToolCall:
     """无副作用预检后的一条工具调用计划。"""
 
     tool_use: ToolUseBlock
     tool: BaseTool | None = None
-    validated_params: dict[str, Any] = Field(default_factory=dict)
+    validated_input: BaseModel | dict[str, Any] | None = None
+    arguments: dict[str, Any] = field(default_factory=dict)
     permission: PermissionDecision | None = None
     human_request: HumanInteractionRequest | None = None
     preflight_result: ToolResult | None = None
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
 
-
-class ToolBatchPlan(BaseModel):
+@dataclass(frozen=True, slots=True)
+class ToolBatchPlan:
     """保持原始顺序的一组工具预检结果。"""
 
-    calls: list[PreparedToolCall] = Field(default_factory=list)
+    calls: tuple[PreparedToolCall, ...] = ()
 
     @property
     def first_human_gate(self) -> PreparedToolCall | None:
@@ -201,7 +203,7 @@ class ToolExecutor:
     ) -> ToolBatchPlan:
         """在不触发执行生命周期的情况下预检一批工具调用。"""
         calls = [self._prepare_call(tool_use, context) for tool_use in tool_uses]
-        return ToolBatchPlan(calls=calls)
+        return ToolBatchPlan(calls=tuple(calls))
 
     async def execute_prepared(
         self,
@@ -211,8 +213,8 @@ class ToolExecutor:
         approved_tool_call_id: str | None = None,
         effect_guard: ToolEffectGuard | None = None,
     ) -> ToolResult:
-        """重新验证当前权限后执行一条预检调用。"""
-        current = self._prepare_call(prepared.tool_use, context)
+        """刷新当前权限后执行一条已完成输入校验的调用。"""
+        current = self._refresh_permission(prepared, context)
         return await self._execute_current(
             current,
             context,
@@ -256,52 +258,19 @@ class ToolExecutor:
         tool: BaseTool | None = None
         try:
             tool = self.registry.get(tool_use.name)
-            params = tool.validate_input(tool_use.input)
-            raw_params = params.model_dump() if isinstance(params, BaseModel) else dict(params)
-            decision = self.permission_policy.check(tool, raw_params, context)
-            preflight_result: ToolResult | None = None
-            if decision.effect is PermissionEffect.DENY:
-                preflight_result = self._error_result(
-                    tool_use,
-                    "PERMISSION_ERROR",
-                    decision.reason,
-                    details={
-                        "require_confirmation": False,
-                        "effect": decision.effect.value,
-                        **decision.metadata,
-                    },
-                )
-            elif (
-                tool.definition.group == "human"
-                and decision.effect is PermissionEffect.REQUIRE_HUMAN
-            ):
-                preflight_result = self._error_result(
-                    tool_use,
-                    "PERMISSION_ERROR",
-                    "human interaction tool 不能同时要求额外人工授权",
-                    details={
-                        "require_confirmation": True,
-                        "effect": decision.effect.value,
-                        **decision.metadata,
-                    },
-                )
-            human_request = None
-            if preflight_result is None:
-                human_request = _human_interaction_request(
-                    tool_use,
-                    tool,
-                    raw_params,
-                    decision,
-                    context,
-                )
-            return PreparedToolCall(
+            validated_input = tool.validate_input(tool_use.input)
+            arguments = (
+                validated_input.model_dump()
+                if isinstance(validated_input, BaseModel)
+                else dict(validated_input)
+            )
+            prepared = PreparedToolCall(
                 tool_use=tool_use,
                 tool=tool,
-                validated_params=raw_params,
-                permission=decision,
-                human_request=human_request,
-                preflight_result=preflight_result,
+                validated_input=validated_input,
+                arguments=arguments,
             )
+            return self._refresh_permission(prepared, context)
         except IrisToolNotFoundError:
             return PreparedToolCall(
                 tool_use=tool_use,
@@ -323,6 +292,84 @@ class ToolExecutor:
                 tool=tool,
                 preflight_result=self._error_result(tool_use, "PERMISSION_ERROR", str(exc)),
             )
+
+    def _refresh_permission(
+        self,
+        prepared: PreparedToolCall,
+        context: ToolExecutionContext,
+    ) -> PreparedToolCall:
+        """只刷新已校验调用的权限与 HITL 投影。"""
+        tool = prepared.tool
+        validated_input = prepared.validated_input
+        if tool is None or validated_input is None:
+            return prepared
+        try:
+            decision = self.permission_policy.check(tool, prepared.arguments, context)
+            preflight_result = self._permission_preflight_result(
+                prepared.tool_use,
+                tool,
+                decision,
+            )
+            human_request = (
+                None
+                if preflight_result is not None
+                else _human_interaction_request(
+                    prepared.tool_use,
+                    tool,
+                    validated_input,
+                    prepared.arguments,
+                    decision,
+                    context,
+                )
+            )
+            return replace(
+                prepared,
+                permission=decision,
+                human_request=human_request,
+                preflight_result=preflight_result,
+            )
+        except Exception as exc:
+            return replace(
+                prepared,
+                permission=None,
+                human_request=None,
+                preflight_result=self._error_result(
+                    prepared.tool_use,
+                    "PERMISSION_ERROR",
+                    str(exc),
+                ),
+            )
+
+    def _permission_preflight_result(
+        self,
+        tool_use: ToolUseBlock,
+        tool: BaseTool,
+        decision: PermissionDecision,
+    ) -> ToolResult | None:
+        """把当前 permission decision 投影为预检错误。"""
+        if decision.effect is PermissionEffect.DENY:
+            return self._error_result(
+                tool_use,
+                "PERMISSION_ERROR",
+                decision.reason,
+                details={
+                    "require_confirmation": False,
+                    "effect": decision.effect.value,
+                    **decision.metadata,
+                },
+            )
+        if tool.definition.group == "human" and decision.effect is PermissionEffect.REQUIRE_HUMAN:
+            return self._error_result(
+                tool_use,
+                "PERMISSION_ERROR",
+                "human interaction tool 不能同时要求额外人工授权",
+                details={
+                    "require_confirmation": True,
+                    "effect": decision.effect.value,
+                    **decision.metadata,
+                },
+            )
+        return None
 
     def _permission_error(
         self,
@@ -381,7 +428,8 @@ class ToolExecutor:
         """执行已通过当前鉴权的调用及其生命周期。"""
         tool_use = prepared.tool_use
         tool = cast(BaseTool, prepared.tool)
-        params = prepared.validated_params
+        validated_input = cast(BaseModel | dict[str, Any], prepared.validated_input)
+        arguments = prepared.arguments
         context.call_id = tool_use.id
         context.tool_name = tool_use.name
         if self.circuit_breaker is not None:
@@ -401,12 +449,12 @@ class ToolExecutor:
         if context.cancellation is not None:
             context.cancellation.raise_if_requested()
         try:
-            middleware_error = await self._run_before_call(tool, params, context)
+            middleware_error = await self._run_before_call(tool, arguments, context)
             if middleware_error is not None:
                 self._record_breaker_result(tool.name, middleware_error)
                 return middleware_error
             try:
-                result = await tool.arun(params, context)
+                result = await tool.arun(validated_input, context)
             except IrisCancellationRequestedError:
                 raise
             except Exception as exc:
@@ -534,8 +582,8 @@ class ToolExecutor:
             return False
         try:
             return prepared.tool.is_read_only(
-                prepared.validated_params
-            ) and prepared.tool.is_concurrency_safe(prepared.validated_params)
+                prepared.arguments
+            ) and prepared.tool.is_concurrency_safe(prepared.arguments)
         except Exception:
             return False
 
@@ -698,7 +746,8 @@ def _copy_context_for_parallel_call(
 def _human_interaction_request(
     tool_use: ToolUseBlock,
     tool: BaseTool,
-    params: dict[str, Any],
+    validated_input: BaseModel | dict[str, Any],
+    arguments: dict[str, Any],
     decision: PermissionDecision,
     context: ToolExecutionContext,
 ) -> HumanInteractionRequest | None:
@@ -706,13 +755,13 @@ def _human_interaction_request(
     if tool.definition.group == "human":
         builder = getattr(tool, "build_interaction_prompt", None)
         if callable(builder):
-            prompt = builder(params=params)
+            prompt = builder(params=validated_input)
     elif decision.effect is PermissionEffect.REQUIRE_HUMAN:
         prompt = PermissionPrompt(reason=decision.reason)
     if prompt is None:
         return None
 
-    tool_call = _tool_call_snapshot(tool_use, tool, params, context)
+    tool_call = _tool_call_snapshot(tool_use, tool, arguments, context)
     return HumanInteractionRequest(tool_call=tool_call, prompt=prompt)
 
 

--- a/src/iris/tools/permissions.py
+++ b/src/iris/tools/permissions.py
@@ -93,7 +93,7 @@ class WorkspacePolicy:
         raw_path = Path(path)
         candidate = raw_path if raw_path.is_absolute() else root / raw_path
         resolved = candidate.resolve(strict=False)
-        if not self.is_within_workspace(resolved, root):
+        if not _is_resolved_within(resolved, root):
             raise IrisToolValidationError(
                 "PATH_OUTSIDE_WORKSPACE: 路径不在 workspace 内",
                 path=path,
@@ -103,11 +103,19 @@ class WorkspacePolicy:
 
     def is_within_workspace(self, path: Path, workspace_root: Path) -> bool:
         """判断路径是否在 workspace 内。"""
-        try:
-            path.resolve(strict=False).relative_to(workspace_root.resolve())
-        except ValueError:
-            return False
-        return True
+        return _is_resolved_within(
+            path.resolve(strict=False),
+            workspace_root.resolve(strict=False),
+        )
+
+
+def _is_resolved_within(path: Path, root: Path) -> bool:
+    """判断两个已 resolve 路径的包含关系。"""
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
 
 
 class PermissionPolicy:

--- a/src/iris/tools/registry.py
+++ b/src/iris/tools/registry.py
@@ -71,20 +71,16 @@ class ToolRegistry:
     #               Tool Registration
     # ==========================================
     # region
-    def register(self, tool: BaseTool, *, on_conflict: str = "raise") -> None:
+    def register(self, tool: BaseTool) -> None:
         """注册对象式工具。
 
         确保新工具的主名称与别名与现有系统完全隔离，不产生冲突。
 
         Args:
             tool (BaseTool): 要注册的工具实例。
-            on_conflict (str): 发生同名时的决策策略。
-
         Raises:
-            IrisToolValidationError: 当名称、别名产生冲突或 on_conflict 不为 raise 时。
+            IrisToolValidationError: 当名称或别名产生冲突时。
         """
-        if on_conflict != "raise":
-            raise IrisToolValidationError("阶段 1 只支持 raise 冲突策略", on_conflict=on_conflict)
         self._validate_available_name(tool.definition.name)
         for alias in tool.definition.aliases:
             self._validate_available_name(alias)

--- a/tests/harness/test_manager_observer_bounds.py
+++ b/tests/harness/test_manager_observer_bounds.py
@@ -91,14 +91,6 @@ def test_session_manager_rejects_non_positive_capacities(
     with pytest.raises(ValueError, match=keyword):
         SessionManager(runner, "session-invalid-capacity", **{keyword: 0})
 
-    if keyword == "max_pending_steer":
-        with pytest.raises(ValueError, match=keyword):
-            SessionManager(
-                runner,
-                "session-invalid-capacity-type",
-                max_pending_steer=cast(int, 1.5),
-            )
-
 
 @pytest.mark.asyncio
 async def test_busy_admission_rejects_before_queue_or_event_side_effects(tmp_path: Path) -> None:

--- a/tests/harness/test_runner_budget_deadline.py
+++ b/tests/harness/test_runner_budget_deadline.py
@@ -228,7 +228,7 @@ async def test_deadline_signal_before_effect_guard_prevents_new_tool_effect(
             context: ToolExecutionContext,
         ) -> PermissionDecision:
             self.checks += 1
-            if self.checks == 3:
+            if self.checks == 2:
                 assert context.cancellation is not None
                 clock.advance(seconds=2)
                 cast(Any, context.cancellation).request_deadline()
@@ -241,11 +241,12 @@ async def test_deadline_signal_before_effect_guard_prevents_new_tool_effect(
     registry = ToolRegistry()
     registry.register_function(effect, description="副作用")
     store = InMemoryLifecycleStore()
+    policy = DeadlineOnExecutePolicy()
     runner = AgentRunner(
         runtime=build_runtime(
             tmp_path,
             registry=registry,
-            permission_policy=DeadlineOnExecutePolicy(),
+            permission_policy=policy,
             provider=StaticProvider(
                 tool_response(ToolUseBlock(id="deadline-effect-1", name="effect", input={}))
             ),
@@ -261,6 +262,7 @@ async def test_deadline_signal_before_effect_guard_prevents_new_tool_effect(
 
     assert result.run.stop_reason is RunStopReason.DEADLINE_EXCEEDED
     assert effects == []
+    assert policy.checks == 2
     [tool_call] = store.list_tool_calls("run-deadline-effect")
     assert tool_call.phase is ToolCallPhase.PREPARED
     [tool_result] = store.load_session("default").messages[-1].tool_results

--- a/tests/performance/test_lifecycle_baseline.py
+++ b/tests/performance/test_lifecycle_baseline.py
@@ -83,6 +83,7 @@ def _create_port(
         store=store,
         run=created.run,
         activation_id="activation_1",
+        cursor=before,
         clock=lambda: _NOW,
         event_sink=[],
     )

--- a/tests/runtime/test_commit_port.py
+++ b/tests/runtime/test_commit_port.py
@@ -66,6 +66,7 @@ def _store_commit_port(
         store=store,
         run=created.run,
         activation_id="activation_1",
+        cursor=before,
         clock=lambda: NOW,
         event_sink=[] if event_sink is None else event_sink,
         durable_event_callback=durable_event_callback,
@@ -267,6 +268,7 @@ def test_store_commit_port_observes_cancellation_from_second_sqlite_store(
         store=owner,
         run=created.run,
         activation_id="activation_1",
+        cursor=before,
         clock=lambda: NOW,
         event_sink=events,
     )

--- a/tests/runtime/test_execute.py
+++ b/tests/runtime/test_execute.py
@@ -15,7 +15,7 @@ from fakes import (
     resume_activation,
     start_activation,
 )
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from iris.agents import AgentConfig
 from iris.context import ContextBuildInput, ContextSection, ContextSlot
@@ -61,6 +61,7 @@ from iris.tools import (
     PermissionPolicy,
     ReadFileState,
     ToolCapability,
+    ToolDefinition,
     ToolErrorInfo,
     ToolExecutionContext,
     ToolExecutor,
@@ -123,6 +124,37 @@ def _tool_batch_response(calls: list[ToolUseBlock]) -> LLMResponse:
         output_tokens=3,
         total_tokens=8,
     )
+
+
+class _CountingSerialTool(BaseTool):
+    """记录 runtime tool batch 对每条输入的校验次数。"""
+
+    definition = ToolDefinition(
+        name="counting_serial",
+        description="记录串行工具校验次数",
+        input_schema={"type": "object"},
+        capabilities={ToolCapability.WRITE},
+    )
+
+    def __init__(self) -> None:
+        self.validation_calls: dict[str, int] = {}
+
+    def validate_input(self, params: dict[str, Any]) -> dict[str, Any]:
+        value = str(params["value"])
+        self.validation_calls[value] = self.validation_calls.get(value, 0) + 1
+        return {"value": value}
+
+    async def arun(
+        self,
+        params: BaseModel | dict[str, Any],
+        context: ToolExecutionContext,
+    ) -> ToolResult:
+        assert isinstance(params, dict)
+        return ToolResult(
+            tool_use_id=context.call_id,
+            tool_name=context.tool_name,
+            content=[TextBlock(text=str(params["value"]))],
+        )
 
 
 def test_steering_input_requires_user_message() -> None:
@@ -605,6 +637,39 @@ async def test_execute_steers_only_after_final_ordered_tool_result(
         ("acknowledge", "submission-1", None),
         ("claim", activation.run_id, activation.activation_id),
     ]
+
+
+@pytest.mark.asyncio
+async def test_execute_validates_serial_tool_batch_once_per_call(tmp_path: Path) -> None:
+    """同一 activation 的串行工具批次复用首次 preflight 计划。"""
+    tool = _CountingSerialTool()
+    registry = ToolRegistry()
+    registry.register(tool)
+    calls = [
+        ToolUseBlock(
+            id=f"counting-{index}",
+            name=tool.name,
+            input={"value": str(index)},
+        )
+        for index in range(5)
+    ]
+    provider = FakeProvider([_tool_batch_response(calls), _text_response("完成")])
+    runtime = _runtime(
+        provider=provider,
+        tmp_path=tmp_path,
+        registry=registry,
+        permission_policy=DefaultPermissionPolicy(write_mode="allow"),
+    )
+    activation = start_activation()
+
+    result = await runtime.execute(
+        activation,
+        commits=FakeRuntimeCommitPort(activation),
+        cancellation=MutableCancellationSignal(),
+    )
+
+    assert result.outcome is RuntimeActivationOutcome.COMPLETED
+    assert tool.validation_calls == {str(index): 1 for index in range(5)}
 
 
 @pytest.mark.asyncio

--- a/tests/skill/test_skill_models.py
+++ b/tests/skill/test_skill_models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 from typing import Any
 
@@ -53,11 +54,6 @@ def _model_cases() -> tuple[tuple[type[BaseModel], dict[str, Any], str], ...]:
     return (
         (SkillMetadata, _metadata_values(), "name"),
         (
-            SkillDiagnostic,
-            {"code": "name_mismatch", "message": "Name differs"},
-            "code",
-        ),
-        (
             SkillDiscoveryOptions,
             {
                 "workspace_root": Path("C:/workspace"),
@@ -104,6 +100,15 @@ def test_skill_models_forbid_extra_fields() -> None:
             model_type.model_validate({**values, "unexpected": True})
 
 
+def test_skill_diagnostic_is_frozen_process_local_dataclass() -> None:
+    diagnostic = SkillDiagnostic(code="name_mismatch", message="Name differs")
+
+    with pytest.raises(FrozenInstanceError):
+        diagnostic.code = "changed"  # type: ignore[misc]
+    with pytest.raises(TypeError, match="unexpected"):
+        SkillDiagnostic(code="name_mismatch", message="Name differs", unexpected=True)  # type: ignore[call-arg]
+
+
 def test_skill_scope_only_contains_project() -> None:
     assert tuple(SkillScope) == (SkillScope.PROJECT,)
     assert SkillScope.PROJECT.value == "project"
@@ -115,46 +120,11 @@ def test_skill_constants_are_stable() -> None:
     assert MAX_DESCRIPTION_CHARS == 1024
 
 
-@pytest.mark.parametrize(
-    "name",
-    ("example", "example-skill", "skill2", "2-skill"),
-)
-def test_skill_metadata_accepts_lowercase_kebab_case_names(name: str) -> None:
-    metadata = SkillMetadata(**_metadata_values(name=name))
-
-    assert metadata.name == name
-
-
-@pytest.mark.parametrize(
-    "name",
-    ("Example", "example_skill", "example skill", "-example", "example-", ""),
-)
-def test_skill_metadata_rejects_invalid_names(name: str) -> None:
-    with pytest.raises(ValidationError, match="name"):
-        SkillMetadata(**_metadata_values(name=name))
-
-
-def test_skill_metadata_normalizes_and_truncates_description() -> None:
-    metadata = SkillMetadata(
-        **_metadata_values(description=f"  {'字' * (MAX_DESCRIPTION_CHARS + 1)}  ")
-    )
-
-    assert metadata.description == "字" * MAX_DESCRIPTION_CHARS
-    assert metadata.description_truncated is True
-
-
 def test_skill_metadata_preserves_precomputed_truncation() -> None:
-    metadata = SkillMetadata(
-        **_metadata_values(description="Short", description_truncated=True)
-    )
+    metadata = SkillMetadata(**_metadata_values(description="Short", description_truncated=True))
 
     assert metadata.description == "Short"
     assert metadata.description_truncated is True
-
-
-def test_skill_metadata_rejects_blank_description() -> None:
-    with pytest.raises(ValidationError, match="description"):
-        SkillMetadata(**_metadata_values(description="   "))
 
 
 @pytest.mark.parametrize("max_chars", (True, False, 0, -1, "10"))
@@ -167,12 +137,3 @@ def test_discovery_options_require_a_strict_positive_description_limit(
             roots=((SkillScope.PROJECT, Path("C:/workspace/.agents/skills")),),
             max_description_chars=max_chars,  # type: ignore[arg-type]
         )
-
-
-@pytest.mark.parametrize("field_name", ("code", "message"))
-def test_diagnostic_rejects_blank_required_text(field_name: str) -> None:
-    values = {"code": "invalid_skill", "message": "Invalid skill"}
-    values[field_name] = "   "
-
-    with pytest.raises(ValidationError, match=field_name):
-        SkillDiagnostic(**values)

--- a/tests/skill/test_skill_tool.py
+++ b/tests/skill/test_skill_tool.py
@@ -96,7 +96,7 @@ async def test_valid_skill_returns_markdown_and_records_real_read_path(
     tool = LoadSkillTool(registry)
     context = ToolExecutionContext(workspace_root=tmp_path)
 
-    result = await tool.arun({"name": "example-skill"}, context)
+    result = await tool.arun(LoadSkillInput(name="example-skill"), context)
 
     expected = "\n".join(skill_file.read_text(encoding="utf-8").splitlines()[:1000])
     assert result.is_error is False
@@ -133,7 +133,7 @@ async def test_missing_registry_name_returns_retryable_error(tmp_path: Path) -> 
     registry, _ = _registry(tmp_path)
 
     result = await LoadSkillTool(registry).arun(
-        {"name": "missing-skill"},
+        LoadSkillInput(name="missing-skill"),
         ToolExecutionContext(workspace_root=tmp_path),
     )
 
@@ -160,7 +160,7 @@ async def test_post_discovery_symlink_escape_returns_path_error_without_secret(
 
     with caplog.at_level(logging.WARNING, logger="iris.skill.tool"):
         result = await LoadSkillTool(registry).arun(
-            {"name": "example-skill"},
+            LoadSkillInput(name="example-skill"),
             ToolExecutionContext(workspace_root=tmp_path),
         )
 
@@ -188,7 +188,7 @@ async def test_post_discovery_sibling_retarget_returns_path_error_without_secret
     _symlink_or_skip(skill_file, sibling_file)
 
     result = await LoadSkillTool(registry).arun(
-        {"name": "example-skill"},
+        LoadSkillInput(name="example-skill"),
         ToolExecutionContext(workspace_root=tmp_path),
     )
 
@@ -204,7 +204,7 @@ async def test_deleted_skill_file_returns_retryable_read_error(tmp_path: Path) -
     skill_file.unlink()
 
     result = await LoadSkillTool(registry).arun(
-        {"name": "example-skill"},
+        LoadSkillInput(name="example-skill"),
         ToolExecutionContext(workspace_root=tmp_path),
     )
 
@@ -224,7 +224,7 @@ async def test_non_utf8_skill_returns_retryable_read_error(tmp_path: Path) -> No
     skill_file.write_bytes(b"\xff\xfe\x00")
 
     result = await LoadSkillTool(registry).arun(
-        {"name": "example-skill"},
+        LoadSkillInput(name="example-skill"),
         ToolExecutionContext(workspace_root=tmp_path),
     )
 
@@ -240,7 +240,7 @@ async def test_loader_preserves_file_service_thousand_line_limit(tmp_path: Path)
     registry, _ = _registry(tmp_path, body=body)
 
     result = await LoadSkillTool(registry).arun(
-        {"name": "example-skill"},
+        LoadSkillInput(name="example-skill"),
         ToolExecutionContext(workspace_root=tmp_path),
     )
 

--- a/tests/store/test_lifecycle_sqlite_faults.py
+++ b/tests/store/test_lifecycle_sqlite_faults.py
@@ -30,6 +30,7 @@ from iris.lifecycle import (
     RunCheckpoint,
     RunCommit,
     RunErrorInfo,
+    RunStopReason,
     RunToolCallRecord,
     RunUsage,
     SuspendRun,
@@ -340,7 +341,7 @@ def test_partial_session_message_insert_rolls_back_terminal_closure(
                         run_id="run-1",
                         expected_run_revision=claimed.run.revision,
                         activation_id="act-1",
-                        stop_reason="outcome_unknown",
+                        stop_reason=RunStopReason.OUTCOME_UNKNOWN,
                         error=RunErrorInfo(
                             code="TOOL_OUTCOME_UNKNOWN",
                             message="工具结果不可证明",

--- a/tests/store/test_lifecycle_store_contract.py
+++ b/tests/store/test_lifecycle_store_contract.py
@@ -7,6 +7,7 @@ import json
 import sqlite3
 import subprocess
 import sys
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Protocol, cast
@@ -52,6 +53,7 @@ from iris.lifecycle import (
     RunControlSnapshot,
     RunErrorInfo,
     RunLimits,
+    RunStopReason,
     RunToolCallRecord,
     RunUsage,
     SuspendRun,
@@ -591,7 +593,7 @@ def test_session_lane_read_tracks_non_terminal_owner_without_mutation(
             run_id="run-1",
             expected_run_revision=waiting.run.revision,
             activation_id=None,
-            stop_reason="cancelled",
+            stop_reason=RunStopReason.CANCELLED,
             now=_T2,
         )
     )
@@ -621,7 +623,7 @@ def test_session_lane_read_tracks_non_terminal_owner_without_mutation(
             run_id="run-2",
             expected_run_revision=requested.run.revision,
             activation_id="activation-2",
-            stop_reason="cancelled",
+            stop_reason=RunStopReason.CANCELLED,
             now=_T3,
         )
     )
@@ -790,11 +792,10 @@ def test_claim_batch_respects_durable_cancellation_fence(
     )
     first = lifecycle_store.claim_tool_call(first_command)
     second = lifecycle_store.claim_tool_call(
-        first_command.model_copy(
-            update={
-                "expected_run_revision": first.run.revision,
-                "tool_call_id": "call-2",
-            }
+        replace(
+            first_command,
+            expected_run_revision=first.run.revision,
+            tool_call_id="call-2",
         )
     )
     cancelled = lifecycle_store.request_cancellation(
@@ -812,11 +813,10 @@ def test_claim_batch_respects_durable_cancellation_fence(
     assert replay.events == ()
     with pytest.raises(IrisRunStateError, match="取消"):
         lifecycle_store.claim_tool_call(
-            first_command.model_copy(
-                update={
-                    "expected_run_revision": cancelled.run.revision,
-                    "tool_call_id": "call-3",
-                }
+            replace(
+                first_command,
+                expected_run_revision=cancelled.run.revision,
+                tool_call_id="call-3",
             )
         )
     assert lifecycle_store.list_events("run-1") == events_after_cancel
@@ -956,18 +956,17 @@ def test_resolve_exact_response_replays_but_different_response_conflicts(
     assert replay.events == ()
     assert replay.run.revision == resolved.run.revision
     refreshed_replay = lifecycle_store.resolve_interaction(
-        command.model_copy(
-            update={
-                "expected_run_revision": resolved.run.revision,
-                "expected_interaction_version": resolved.interaction.version,
-            }
+        replace(
+            command,
+            expected_run_revision=resolved.run.revision,
+            expected_interaction_version=resolved.interaction.version,
         )
     )
     assert refreshed_replay.events == ()
     assert refreshed_replay.run == resolved.run
     with pytest.raises(IrisRunConflictError):
         lifecycle_store.resolve_interaction(
-            command.model_copy(update={"response": QuestionInteractionResponse(answer="停止")})
+            replace(command, response=QuestionInteractionResponse(answer="停止"))
         )
 
 
@@ -1207,7 +1206,7 @@ def test_cancellation_request_is_once_only_and_does_not_release_active_lane(
 
     assert lifecycle_store.request_cancellation(command).events == ()
     refreshed_replay = lifecycle_store.request_cancellation(
-        command.model_copy(update={"expected_run_revision": requested.run.revision})
+        replace(command, expected_run_revision=requested.run.revision)
     )
     assert refreshed_replay.events == ()
     assert refreshed_replay.run == requested.run
@@ -1269,7 +1268,7 @@ def test_finish_exact_replay_is_noop_and_releases_lane(
         run_id="run-1",
         expected_run_revision=created.run.revision,
         activation_id="activation-1",
-        stop_reason="completed",
+        stop_reason=RunStopReason.COMPLETED,
         assistant_message=Msg.assistant("done"),
         now=_T1,
     )
@@ -1311,7 +1310,7 @@ def test_terminal_finish_closes_claimed_and_prepared_history_atomically(
         run_id="run-1",
         expected_run_revision=claim_revision,
         activation_id="activation-1",
-        stop_reason="outcome_unknown",
+        stop_reason=RunStopReason.OUTCOME_UNKNOWN,
         error=RunErrorInfo(
             code="TOOL_OUTCOME_UNKNOWN",
             message="工具结果不可证明",
@@ -1414,7 +1413,7 @@ def test_safe_recovery_rejects_unresolved_durable_claim(
                 expected_run_revision=claimed.run.revision,
                 expected_activation_id="activation-1",
                 expected_checkpoint_sequence=claimed.checkpoint.sequence,
-                recovery_disposition="resume",
+                recovery_disposition=RecoveryDisposition.RESUME,
                 new_activation_id="activation-recovery",
                 now=_T3,
             )

--- a/tests/tools/test_human_ask_tool.py
+++ b/tests/tools/test_human_ask_tool.py
@@ -40,8 +40,9 @@ def test_ask_question_input_rejects_empty_or_duplicate_values(value: dict[str, o
 
 
 def test_ask_question_tool_builds_question_prompt() -> None:
-    prompt = AskQuestionTool().build_interaction_prompt(
-        params={"question": "是否继续？", "options": ["继续", "取消"]},
+    tool = AskQuestionTool()
+    prompt = tool.build_interaction_prompt(
+        params=AskQuestionInput(question="是否继续？", options=["继续", "取消"]),
     )
 
     assert isinstance(prompt, QuestionPrompt)
@@ -91,7 +92,7 @@ def test_ask_question_tool_rejects_direct_execution() -> None:
     with pytest.raises(IrisHITLError):
         asyncio.run(
             tool.arun(
-                {"question": "是否继续？"},
+                AskQuestionInput(question="是否继续？"),
                 ToolExecutionContext(workspace_root="."),
             )
         )


### PR DESCRIPTION
- 工具输入仅在首次边界校验，执行前独立刷新权限
- 使用类型化状态迁移与进程内数据类消除重复模型重建
- 同步相关 README 与回归测试